### PR TITLE
refactor: generalize test_validate to load peer + errors in fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 venv/
+__pycache__/

--- a/test_validate_config.py
+++ b/test_validate_config.py
@@ -11,21 +11,13 @@ from validate_config import read_yaml, \
 class TestValidateConfig(TestCase):
 
     def test_validate(self):
-        empty_peer = {}
-        empty_peer_errors = [
-          'name must exist',
-          'asn must exist',
-          'ipv4 or ipv6 must exist',
-          'sessions must exist',
-          'wireguard must exist'
-        ]
-        self.assertEqual(list(validate(empty_peer)), empty_peer_errors)
-
-        test_cases = {}
-        for test_case in sorted(os.listdir('tests/fixtures')):
-            test_cases[test_case] = read_yaml(f'tests/fixtures/{test_case}')
-
-        self.assertEqual(list(validate(test_cases['valid_ext_nh'])), [])
+        # load all fixture files, test each
+        for fixture in sorted(os.listdir('tests/fixtures')):
+            test_case = read_yaml(f'tests/fixtures/{fixture}')
+            self.assertEqual(
+                list(validate(test_case['peer'])),
+                test_case['errors'],
+                f'test_case::{fixture}')
 
     def test_validate_unique_peers(self):
         not_unique = [

--- a/tests/fixtures/empty
+++ b/tests/fixtures/empty
@@ -1,0 +1,9 @@
+---
+peer: {}
+
+errors:
+  - name must exist
+  - asn must exist
+  - ipv4 or ipv6 must exist
+  - sessions must exist
+  - wireguard must exist

--- a/tests/fixtures/valid_ext_nh
+++ b/tests/fixtures/valid_ext_nh
@@ -1,11 +1,14 @@
 ---
-name: TEST-1
-asn: 424242000
-ipv6: fe80::1111
-multiprotocol: true
-extended_nexthop: true
-sessions: [ipv6]
-wireguard:
-  remote_address: 2001:db8::1
-  remote_port: 33333
-  public_key: vLfdP6SrkTfOnn/iYPM/ytMIU/vseZVNoAdgNbo1yV4=
+peer:
+  name: TEST-1
+  asn: 424242000
+  ipv6: fe80::1111
+  multiprotocol: true
+  extended_nexthop: true
+  sessions: [ipv6]
+  wireguard:
+    remote_address: 2001:db8::1
+    remote_port: 33333
+    public_key: vLfdP6SrkTfOnn/iYPM/ytMIU/vseZVNoAdgNbo1yV4=
+
+errors: []


### PR DESCRIPTION
Just a simple refactor to contain the expected errors for a fixture within that fixture as not to create a long `test_validate` for each case.

Simply, the fixture will have a `peer` key that contains a test peer config, and then `errors` key containing the expected errors when that test is fine.

The tests will load up all the fixtures, test the peer config, and compare the errors generated to be what is in the `errors`

```
-> python -m unittest test_validate_config.py
FWARNING:root:private asn: '65000' accepted
.......
======================================================================
FAIL: test_validate (test_validate_config.TestValidateConfig.test_validate)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/yzguy/Projects/routedbits/dn42-peers/test_validate_config.py", line 17, in test_validate
    self.assertEqual(
AssertionError: Lists differ: ['name must exist', 'asn must exist', 'ipv[64 chars]ist'] != []

First list contains 5 additional elements.
First extra element 0:
'name must exist'

+ []
- ['name must exist',
-  'asn must exist',
-  'ipv4 or ipv6 must exist',
-  'sessions must exist',
-  'wireguard must exist'] : test_case::empty
```