### PR TITLE
feat: add support for peer remote_address as a DNS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please allow some time for the process to complete.
   extended_nexthop: true  # Enable BGP Extended Nexthop Capability
   sessions: [ipv6]        # Protocol to use for session connection (ipv6)
   wireguard:
-    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (no DNS names)
+    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
     public_key: abdcefabdcefabdcefabdcefabdcefabdcefabdcefg=   # Your WireGuard Public Key
 ```
@@ -51,7 +51,7 @@ Please allow some time for the process to complete.
   multiprotocol: true     # Send both IPv4 and IPv6 AFIs in the same BGP session
   sessions: [ipv6]        # Protocol to use for session connection (ipv4 or ipv6)
   wireguard:
-    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (no DNS names)
+    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
     public_key: abdcefabdcefabdcefabdcefabdcefabdcefabdcefg=   # Your WireGuard Public Key
 ```
@@ -65,7 +65,7 @@ Please allow some time for the process to complete.
   ipv6: fe80::1234        # Your IPv6 tunnel address (Link-local preferred, /64 assumed unless specified)
   sessions: [ipv4,ipv6]   # Protocol to use for session connection (ipv4 and ipv6)
   wireguard:
-    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (no DNS names)
+    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
     public_key: abdcefabdcefabdcefabdcefabdcefabdcefabdcefg=   # Your WireGuard Public Key
 ```
@@ -78,7 +78,7 @@ Please allow some time for the process to complete.
   ipv4: 172.20.0.1        # Your IPv4 tunnel/endpoint address
   sessions: [ipv4]        # Protocol to use for session connection (ipv4)
   wireguard:
-    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (no DNS names)
+    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
     public_key: abdcefabdcefabdcefabdcefabdcefabdcefabdcefg=   # Your WireGuard Public Key
 ```
@@ -91,7 +91,7 @@ Please allow some time for the process to complete.
   ipv6: fe80::1234        # Your IPv6 tunnel address (Link-local preferred, /64 assumed unless specified)
   sessions: [ipv6]        # Protocol to use for session connection (ipv4 or ipv6)
   wireguard:
-    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (no DNS names)
+    remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
     public_key: abdcefabdcefabdcefabdcefabdcefabdcefabdcefg=   # Your WireGuard Public Key
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+dnspython==2.4.2
 github-action-utils==1.1.0
 PyYAML==6.0.1

--- a/test_validate_config.py
+++ b/test_validate_config.py
@@ -168,10 +168,27 @@ class TestValidateConfig(TestCase):
         }
         self.assertIn("wireguard.remote_address: must exist", validate_wireguard(no_remote_address))
 
+        remote_address_invalid_msg = "wireguard.remote_address is not a valid IPv4/IPv6 address or no DNS A/AAAA record found"
+
         remote_address_not_ip = {
             'remote_address': 'foobar'
         }
-        self.assertIn("wireguard.remote_address is not a valid IPv4 or IPv6 address", validate_wireguard(remote_address_not_ip))
+        self.assertIn(remote_address_invalid_msg, validate_wireguard(remote_address_not_ip))
+
+        remote_address_valid_ip = {
+            'remote_address': '192.0.2.1'
+        }
+        self.assertNotIn(remote_address_invalid_msg, validate_wireguard(remote_address_valid_ip))
+
+        remote_address_invalid_fqdn = {
+            'remote_address': 'foobar.non_exist_tld'
+        }
+        self.assertIn(remote_address_invalid_msg, validate_wireguard(remote_address_invalid_fqdn))
+
+        remote_address_valid_fqdn = {
+            'remote_address': 'google.com'
+        }
+        self.assertNotIn(remote_address_invalid_msg, validate_wireguard(remote_address_valid_fqdn))
 
         no_remote_port = {
             'remote_address': '192.0.2.1',


### PR DESCRIPTION
Adds support for `remote_address` as a FQDN and update unit tests.

Since the upstream Ansible repo has been updated to resolve DNS names we can now allow peers to specify a FQDN as their endpoint instead of an IPv4/IPv6 address if they wish.

While an IP is still written to the end result configuration (limitation of our platform) they will get updated eventually when Ansible runs again to reconcile the configuration. This should be sufficient enough for this use case. Otherwise future 'road-warrior' WireGuard configuration could better support more dynamically changing peers.