### PR TITLE
fix: set trigger to when pull request is closed

### DIFF
--- a/.github/workflows/dispatch_config.yml
+++ b/.github/workflows/dispatch_config.yml
@@ -1,11 +1,13 @@
 name: Dispatch Configuration
 
 on:
-  push:
+  pull_request:
     branches: [main]
+    types: [closed]
 
 jobs:
   set-limit:
+    if: ${{ github.event.pull_request.merged }}
     name: Set changed routers limit
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +26,7 @@ jobs:
 
   dispatch:
     name: Dispatch configuration job
+    needs: set-limit
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch peer configuration workflow


### PR DESCRIPTION
Update the merge workflow to trigger when the pull request is closed versus a merge to main. This will ensure we still have a reference to the pull request ID required to interrogate which routers have changed, which allows us to appropriately scope updates the correct routers.