### PR TITLE
fix: only continue dispatch when ansible limit is set

### DIFF
--- a/.github/workflows/dispatch_config.yml
+++ b/.github/workflows/dispatch_config.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch peer configuration workflow
+        if: ${{ needs.set-limit.outputs.limit != '' }}
         run: |
           curl -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Authorization: token ${{ secrets.DISPATCH_TOKEN }}" \


### PR DESCRIPTION
Restrict the dispatch job to only when a limit is set. If there are no detected changes, do not dispatch a job.