### PR TITLE
fix: use IPv4 address for AMS1 PIVIPI peering

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -6,6 +6,6 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: nl-eyg.inferior.network
+    remote_address: 204.10.194.74  # nl-eyg.inferior.network
     remote_port: 20207
     public_key: lBYpESYKv+3u/d4Van4EzgOngfPLiCTilAatIFT2gXk=


### PR DESCRIPTION
https://github.com/routedbits/ansible-routedbits-vyos/issues/212

Seems that the DNS used for the PIVIPI-AMS peering does not have an IPv6 address (which we prefer), but is somehow misconfigured in that there is a record created, but no answer.

This is a format error to Bind, but returns a NOERROR from Cloudflare (1.1.1.1)

We will just use the IPv4 address instead of the DNS for this peer.