### PR TITLE
refactor: migrate Kioubit peerings to use DNS

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -29,7 +29,7 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 47.87.173.98
+    remote_address: us2.g-load.eu
     remote_port: 20207
     public_key: 6Cylr9h1xFduAO+5nyXhFI1XJ0+Sw9jCpCDvcqErF1s=
 

--- a/routers/router.fnc1.yml
+++ b/routers/router.fnc1.yml
@@ -17,7 +17,7 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 2a04:bdc7:100:4fee::1
+    remote_address: us3.g-load.eu
     remote_port: 20207
     public_key: sLbzTRr2gfLFb24NPzDOpy8j09Y6zI+a7NkeVMdVSR8=
 

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -63,7 +63,7 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 2a01:4f8:c2c:3b65::1
+    remote_address: de2.g-load.eu
     remote_port: 20207
     public_key: B1xSG/XTJRLd+GrWDsB06BqnIq8Xud93YVh/LYYYtUY=
 

--- a/routers/router.lon1.yml
+++ b/routers/router.lon1.yml
@@ -6,7 +6,7 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 194.29.101.166
+    remote_address: uk1.g-load.eu
     remote_port: 20207
     public_key: sLbzTRr2gfLFb24NPzDOpy8j09Y6zI+a7NkeVMdVSR8=
 

--- a/routers/router.par1.yml
+++ b/routers/router.par1.yml
@@ -6,6 +6,6 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 2001:41d0:304:100::2b75
+    remote_address: fr1.g-load.eu
     remote_port: 20207
     public_key: sLbzTRr2gfLFb24NPzDOpy8j09Y6zI+a7NkeVMdVSR8=


### PR DESCRIPTION
Migrate Kioubit peerings to use DNS instead of IPs directly. Looks like the IP changed for the EWR1 peering