### PR TITLE
fix: remove CIDR from BOOTL0ADER Toronto peering

### DIFF
--- a/routers/router.tor1.yml
+++ b/routers/router.tor1.yml
@@ -1,7 +1,7 @@
 ---
 - name: BOOTL0ADER-TOR
   asn: 4242421838
-  ipv6: fe80::ca75/64
+  ipv6: fe80::ca75
   multiprotocol: true
   extended_nexthop: true
   sessions: [ipv6]


### PR DESCRIPTION
Remove /64 from IP on BOOTL0ADER Toronto peering