### PR TITLE
Revert "refactor: set Kioubit LON1,EWR1 address to IP"

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -29,7 +29,7 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 194.32.145.44
+    remote_address: us2.g-load.eu
     remote_port: 20207
     public_key: 6Cylr9h1xFduAO+5nyXhFI1XJ0+Sw9jCpCDvcqErF1s=
 

--- a/routers/router.lon1.yml
+++ b/routers/router.lon1.yml
@@ -17,7 +17,7 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 194.29.101.166
+    remote_address: uk1.g-load.eu
     remote_port: 20207
     public_key: sLbzTRr2gfLFb24NPzDOpy8j09Y6zI+a7NkeVMdVSR8=
 


### PR DESCRIPTION
Reverts routedbits/dn42-peers#29

We have fixed the DNS lookup logic so we can re-revert this to use DNS again.