### PR TITLE
Revert "fix: use IPv4 address for AMS1 PIVIPI peering"

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -6,6 +6,6 @@
   extended_nexthop: true
   sessions: [ipv6]
   wireguard:
-    remote_address: 204.10.194.74  # nl-eyg.inferior.network
+    remote_address: nl-eyg.inferior.network
     remote_port: 20207
     public_key: lBYpESYKv+3u/d4Van4EzgOngfPLiCTilAatIFT2gXk=


### PR DESCRIPTION
Reverts routedbits/dn42-peers#23

Use DNS for this instead of IP now that we have fixed the DNS lookup logic