### PR TITLE
fix(SERNET): remove prefix notation from peering address

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -47,7 +47,7 @@
 
 - name: SERNET-US-NYC1
   asn: 4242423947
-  ipv6: fe80::3947:7/64
+  ipv6: fe80::3947:7
   multiprotocol: true
   extended_nexthop: true
   sessions: [ipv6]

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -114,7 +114,7 @@
 
 - name: SERNET-DE-FRA1
   asn: 4242423947
-  ipv6: fe80::3947:6/64
+  ipv6: fe80::3947:6
   multiprotocol: true
   extended_nexthop: true
   sessions: [ipv6]

--- a/routers/router.lax1.yml
+++ b/routers/router.lax1.yml
@@ -12,7 +12,7 @@
 
 - name: SERNET-US-LAX1
   asn: 4242423947
-  ipv6: fe80::3947:4/64
+  ipv6: fe80::3947:4
   multiprotocol: true
   extended_nexthop: true
   sessions: [ipv6]

--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -44,7 +44,7 @@
 
 - name: SERNET-HK1
   asn: 4242423947
-  ipv6: fe80::3947:1/64
+  ipv6: fe80::3947:1
   multiprotocol: true
   extended_nexthop: true
   sessions: [ipv6]

--- a/routers/router.tyo1.yml
+++ b/routers/router.tyo1.yml
@@ -47,7 +47,7 @@
 
 - name: SERNET-KR-SEL1
   asn: 4242423947
-  ipv6: fe80::3947:5/64
+  ipv6: fe80::3947:5
   multiprotocol: true
   extended_nexthop: true
   sessions: [ipv6]


### PR DESCRIPTION
Remove prefix notation from peering configuration. This is likely getting confused for special edge cases where `local_ipX` is required to specify an different peering subnet.

An additional fix in the automation repo prevents this from being an issue in the future, however, this is to promote consistency.