### PR TITLE
Update router.mum1.yml

### DIFF
--- a/routers/router.mum1.yml
+++ b/routers/router.mum1.yml
@@ -1,9 +1,10 @@
 ---
 - name: STRYKAR-MUM
   asn: 4242422174
-  ipv4: 172.23.240.224
   ipv6: fe80::2174
-  sessions: [ipv4, ipv6]
+  multiprotocol: true
+  extended_nexthop: true
+  sessions: [ipv6]
   wireguard:
     remote_address: mum1.dn42.4v1.in
     remote_port: 20207


### PR DESCRIPTION
There is a hack to enable link-local addresses on WG interfaces, they have to be part of a pool first.
Let's try your preferred way because I cannot establish a BGP session  anyways with the first configuration - `EBGP peer is not on a shared network and multihop is not configured  {l_addr: (empty), r_addr: (empty)}` in spite of a local address being set.

If you would please provide a short connection summary like last time, it would really help, thank you!