### PR TITLE
feat: allow dynamic wireguard peers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 4
+    commit-message:
+      prefix: "ci(actions): "
+    labels:
+      - maintenance
+    rebase-strategy: auto
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 4
+    commit-message:
+      prefix: "build(deps): "
+    labels:
+      - dependencies
+    rebase-strategy: auto

--- a/test_validate_config.py
+++ b/test_validate_config.py
@@ -163,10 +163,11 @@ class TestValidateConfig(TestCase):
         not_dict = []
         self.assertEqual(validate_wireguard(not_dict), f"wireguard: '{not_dict}' must be type dictionary")
 
-        no_remote_address = {
-            'foo': 'bar'
-        }
-        self.assertIn("wireguard.remote_address: must exist", validate_wireguard(no_remote_address))
+        # allow dynamic peers (no remote address)
+        # no_remote_address = {
+        #     'foo': 'bar'
+        # }
+        # self.assertIn("wireguard.remote_address: must exist", validate_wireguard(no_remote_address))
 
         remote_address_invalid_msg = "wireguard.remote_address is not a valid IPv4/IPv6 address or no DNS A/AAAA record found"
 
@@ -190,10 +191,15 @@ class TestValidateConfig(TestCase):
         }
         self.assertNotIn(remote_address_invalid_msg, validate_wireguard(remote_address_valid_fqdn))
 
-        no_remote_port = {
+        no_remote_port_with_address = {
             'remote_address': '192.0.2.1',
         }
-        self.assertIn("wireguard.remote_port: must exist", validate_wireguard(no_remote_port))
+        self.assertIn("wireguard.remote_port: must exist when remote_address defined", validate_wireguard(no_remote_port_with_address))
+
+        no_address_with_remote_port = {
+            'remote_port': 50001,
+        }
+        self.assertIn("wireguard.remote_address: must exist when remote_port defined", validate_wireguard(no_address_with_remote_port))
 
         remote_port_not_int = {
             'remote_address': '192.0.2.1',

--- a/validate_config.py
+++ b/validate_config.py
@@ -197,9 +197,10 @@ def validate_wireguard(wg):
     if not type(wg) is dict:
         return f"wireguard: '{wg}' must be type dictionary"
 
-    if "remote_address" not in wg.keys():
-        errors.append("wireguard.remote_address: must exist")
-    else:
+    if "remote_address" in wg.keys():
+        if "remote_port" not in wg.keys():
+            errors.append("wireguard.remote_port: must exist when remote_address defined")
+
         try:
             ipaddress.ip_network(wg["remote_address"])
         except ValueError:
@@ -215,9 +216,9 @@ def validate_wireguard(wg):
                         "wireguard.remote_address is not a valid IPv4/IPv6 address or no DNS A/AAAA record found"
                     )
 
-    if "remote_port" not in wg.keys():
-        errors.append("wireguard.remote_port: must exist")
-    else:
+    if "remote_port" in wg.keys():
+        if "remote_address" not in wg.keys():
+            errors.append("wireguard.remote_address: must exist when remote_port defined")
         if not type(wg["remote_port"]) is int:
             errors.append("wireguard.remote_port: must be an integer")
         elif not 0 < wg["remote_port"] <= 65535:

--- a/validate_config.py
+++ b/validate_config.py
@@ -78,6 +78,8 @@ def read_yaml(filename):
 def validate(peer):
     errors = []
 
+    print(f"Validating peer: {peer.get('name', '<missing>')}...", end="")
+
     if "name" in peer:
         errors.append(validate_name(peer["name"]))
     else:
@@ -123,6 +125,11 @@ def validate(peer):
         errors += validate_wireguard(peer["wireguard"])
     else:
         errors.append("wireguard must exist")
+
+    if len(list(filter(None, errors))):
+        print('\033[91m FAIL \033[0m')
+    else:
+        print('\033[92m ok \033[0m')
 
     return filter(None, errors)
 


### PR DESCRIPTION
This PR allows the configuration of dynamic wireguard peers by leaving out `remote_address` and `remote_port` under the WireGuard configuration:

```yaml
- name: TEST-PEER
  asn: 4242420000
  ipv6: fe80::1
  multiprotocol: true
  extended_nexthop: true
  sessions: [ipv6]
  wireguard:
    public_key: 1GBNudioxk6PFrrZm3hDIAOoQvzlurR6buMFv6ZEnkc=
```
