### PR TITLE
feat: add interactive script for new peerings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,35 @@ You can [click here](https://forms.gle/rt9YZ8AoFfX5YmE8A) to submit a peering re
 ### Steps
 
 1. Fork this repository
-2. Update the appropriate [router](routers/) with your peering information
+
+    ```
+    git clone git@github.com:routedbits/dn42-peers.git
+    cd dn42-peers
+    ```
+
+2. Install dependencies
+
+    ```
+    python -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    ```
+
+2. Run the `interactive.py` script and provide the requested information
+    * Alternatively, you can manually update the appropriate [router](routers/) with your peering information
+
+    ```
+    python interactive.py
+    ```
+
 3. Create a PR
+
+    ```
+    git checkout -b AS123456789_LON1
+    git add .
+    git commit -m "Add AS123456789 peering at LON1"
+    git push origin AS123456789_LON1
+    ```
 
 Once approved and merged, we automatically distribute your configuration to the routers in our network.
 Please allow some time for the process to complete.
@@ -40,7 +67,8 @@ Please allow some time for the process to complete.
   ipv6: fe80::1234        # Your IPv6 tunnel address (Link-local preferred, /64 assumed unless specified)
   multiprotocol: true     # Send both IPv4 and IPv6 AFIs in the same BGP session
   extended_nexthop: true  # Enable BGP Extended Nexthop Capability
-  sessions: [ipv6]        # Protocol to use for session connection (ipv6)
+  sessions:               # Protocol to use for session connection (ipv6)
+    - ipv6
   wireguard:
     remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
@@ -55,7 +83,8 @@ Please allow some time for the process to complete.
   ipv4: 172.20.0.1        # Your IPv4 tunnel/endpoint address
   ipv6: fe80::1234        # Your IPv6 tunnel address (Link-local preferred, /64 assumed unless specified)
   multiprotocol: true     # Send both IPv4 and IPv6 AFIs in the same BGP session
-  sessions: [ipv6]        # Protocol to use for session connection (ipv4 or ipv6)
+  sessions:               # Protocol to use for session connection (ipv4 or ipv6)
+    - ipv6
   wireguard:
     remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
@@ -69,7 +98,9 @@ Please allow some time for the process to complete.
   asn: 4242420000         # Your DN42 ASN
   ipv4: 172.20.0.1        # Your IPv4 tunnel/endpoint address
   ipv6: fe80::1234        # Your IPv6 tunnel address (Link-local preferred, /64 assumed unless specified)
-  sessions: [ipv4,ipv6]   # Protocol to use for session connection (ipv4 and ipv6)
+  sessions:               # Protocol to use for session connection (ipv4 and ipv6)
+    - ipv4
+    - ipv6
   wireguard:
     remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
@@ -82,7 +113,8 @@ Please allow some time for the process to complete.
 - name: YOUR-PEER-NAME    # Name your connection; please use capital letters and dashes only
   asn: 4242420000         # Your DN42 ASN
   ipv4: 172.20.0.1        # Your IPv4 tunnel/endpoint address
-  sessions: [ipv4]        # Protocol to use for session connection (ipv4)
+  sessions:               # Protocol to use for session connection (ipv4)
+    - ipv4
   wireguard:
     remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port
@@ -95,7 +127,8 @@ Please allow some time for the process to complete.
 - name: YOUR-PEER-NAME    # Name your connection; please use capital letters and dashes only
   asn: 4242420000         # Your DN42 ASN
   ipv6: fe80::1234        # Your IPv6 tunnel address (Link-local preferred, /64 assumed unless specified)
-  sessions: [ipv6]        # Protocol to use for session connection (ipv4 or ipv6)
+  sessions:               # Protocol to use for session connection (ipv4 or ipv6)
+    - ipv6
   wireguard:
     remote_address: 2001:db8:abcd:ef::1                        # Your clear net/public IPv4 or IPv6 address (or FQDN)
     remote_port: 20207                                         # Your WireGuard Listen Port

--- a/interactive.py
+++ b/interactive.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+
+import argparse
+import yaml
+import validate_config as validations
+
+from os import listdir
+from pathlib import Path
+from validate_config import validate
+
+class output:
+    OK = '\033[92m'
+    WARN = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+
+    def fail(msg):
+        output.print(msg, status=output.FAIL, lines_before=1, lines_after=1)
+
+    def warning(msg):
+        output.print(msg, status=output.WARN, lines_before=1, lines_after=1)
+
+    def ok(msg):
+        output.print(msg, status=output.OK, lines_before=1, lines_after=1)
+
+    def ask(msg, status=str(), lines_before=1, lines_after=0):
+        prompt = '{}{}{}{}{}'.format('\n' * lines_before, status, msg, output.ENDC, '\n' * lines_after)
+        return input(prompt)
+
+    def print(msg, status=str(), lines_before=0, lines_after=0):
+        prompt = '{}{}{}{}{}'.format('\n' * lines_before, status, msg, output.ENDC, '\n' * lines_after)
+        print(prompt)
+
+    def choices(question, options, status=str(), lines_before=0, lines_after=0):
+        output.print(question, lines_after=1)
+        for idx, option in enumerate(options):
+            output.print(f'\t{idx+1}. {option}')
+
+        try:
+            return int(output.ask('Selection: '))
+        except ValueError:
+            output.fail('ERROR: Not a valid selection, try again')
+
+class IndentDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super(IndentDumper, self).increase_indent(flow, False)
+
+def load_router_peers(router):
+    with open(f'routers/{router}.yml', 'r') as fd:
+        peers = yaml.safe_load(fd)
+
+    # no peers set to empty list to avoid NoneType
+    if not peers:
+        peers = []
+
+    return peers
+
+def save_router_peers(router, peers):
+    # Sort peers by name before saving
+    peers = sorted(peers, key=lambda peer: peer['name'])
+
+    with open(f'routers/{router}.yml', 'w') as fd:
+        # YAML document header
+        fd.write('---\n')
+        # Write out each peer to router file (do not sort each peers keys)
+        for peer in peers:
+            fd.write(yaml.dump([peer], Dumper=IndentDumper, sort_keys=False))
+            # Don't write newline after last peer
+            if peer != peers[-1]:
+                fd.write('\n')
+
+def main(args):
+    peer = {}
+
+    # Router
+    router = None
+    while True:
+        question = 'What router would you like to peer at?'
+        routers = sorted([Path(router).stem for router in listdir('routers')])
+
+        try:
+            router = routers[output.choices(question, routers)-1]
+            break
+        except (IndexError, TypeError, ValueError):
+            output.fail('ERROR: Not a valid selection, try again')
+
+    # Name
+    while True:
+        peer_name = output.ask('Peer Name: ')
+        if not (error := validations.validate_name(peer_name)):
+            break
+        output.fail(error)
+    peer['name'] = peer_name
+
+    # ASN
+    while True:
+        try:
+            asn = int(output.ask('DN42 ASN: '))
+            if not (error := validations.validate_asn(asn)):
+                break
+            output.fail(error)
+        except ValueError:
+            output.fail('ERROR: Not an valid ASN number')
+    peer['asn'] = asn
+
+
+    # Type of BGP Peering
+    peering_types = {
+        'mp-bgp-extnh': 'Multi-protocol (IPv4 and IPv6) with Extended Nexthop capability (preferred)',
+        'mp-bgp': 'Multi-protocol (IPv4 and IPv6)',
+        'ipv4v6': 'IPv4 and IPv6 (separate sessions)',
+        'ipv4': 'IPv4 ONLY',
+        'ipv6': 'IPv6 ONLY'
+    }
+    peering_type = None
+    while True:
+        question = 'Which BGP peering type are you requesting?'
+        try:
+            selection = output.choices(question, peering_types.values(), lines_before=1, lines_after=1)
+            peering_type = list(peering_types.keys())[selection-1]
+            break
+        except (ValueError, IndexError):
+            output.fail('ERROR: Not a valid selection, try again')
+
+    # IPv4 Tunnel Address
+    def ipv4_tunnel_address():
+        while True:
+            answer = output.ask('IPv4 tunnel address: ')
+            if not (error := validations.validate_ip(answer, af='ipv4', attrib='ipv4')):
+                break
+            output.fail(error)
+        peer['ipv4'] = answer
+
+    # IPv6 Tunnel Address
+    def ipv6_tunnel_address():
+        while True:
+            answer = output.ask('IPv6 tunnel address (Link-local preferred, /64 assumed unless specified): ')
+            if not (error := validations.validate_ip(answer, af='ipv6', attrib='ipv6')):
+                break
+            output.fail(error)
+        peer['ipv6'] = answer
+
+    # Session Address Family
+    def session_address_family():
+        session = []
+        while True:
+            valid_af = ['ipv4', 'ipv6']
+            answer = output.ask('Session Address Family (ipv4, ipv6): ')
+            if answer in valid_af:
+                session = [answer]
+                break
+            else:
+                output.fail('ERROR: not a valid session address family')
+        return session
+
+    # Multi-protocol (IPv4 and IPv6) with Extended Nexthop capability
+    if peering_type == 'mp-bgp-extnh':
+        ipv6_tunnel_address()
+        peer['multiprotocol'] = True
+        peer['extended_nexthop'] = True
+        peer['sessions'] = ['ipv6']
+
+    # Multi-protocol (IPv4 and IPv6)
+    elif peering_type == 'mp-bgp':
+        session = session_address_family()
+        if 'ipv4' in session:
+            ipv4_tunnel_address()
+        if 'ipv6' in session:
+            ipv6_tunnel_address()
+        peer['multiprotocol'] = True
+        peer['sessions'] = session
+
+    # IPv4 + IPv6
+    elif peering_type == 'ipv4v6':
+        ipv4_tunnel_address()
+        ipv6_tunnel_address()
+        peer['sessions'] = ['ipv4', 'ipv6']
+
+    # IPv4 ONLY
+    elif peering_type == 'ipv4':
+        ipv4_tunnel_address()
+        peer['sessions'] = ['ipv4']
+
+    # IPv6 ONLY
+    elif peering_type == 'ipv6':
+        ipv6_tunnel_address()
+        peer['sessions'] = ['ipv6']
+
+    # Wireguard
+    while True:
+        wireguard = {}
+
+        # Wireguard Endpoint
+        remote_address = output.ask('Wireguard Endpoint: ')
+        if remote_address:
+            wireguard['remote_address'] = remote_address
+
+        # Wireguard Listen Port
+        # Port only required if remote_address specified
+        if remote_address:
+            try:
+                remote_port = int(output.ask('Wireguard Port: '))
+                wireguard['remote_port'] = remote_port
+            except ValueError:
+                output.fail('ERROR: Not a valid port number')
+                continue
+
+        # Wireguard Public Key
+        public_key = output.ask('Wireguard Public Key: ')
+        if public_key:
+            wireguard['public_key'] = public_key
+
+        if not (errors := validations.validate_wireguard(wireguard)):
+            break
+
+        for error in errors:
+            output.fail(error)
+    peer['wireguard'] = wireguard
+
+    print()
+
+    # Final validation as a whole
+    peer_errors = list(validate(peer))
+    for peer_error in peer_errors:
+        output.fail(peer_error)
+
+    if args.stdout:
+        # Output YAML to stdout
+        peers = [peer]
+        output.ok('--- Generated Configuration ---')
+        output.print(f'# routers/{router}.yml', lines_after=1)
+        output.print(yaml.dump(peers, sort_keys=False))
+    else:
+        # Write YAML to selected router
+        peers = load_router_peers(router)
+        peers.append(peer)
+        save_router_peers(router, peers)
+        output.ok(f'Successfully saved peer to {router}.yml')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Generate dn42-peers configuration')
+    parser.add_argument('--stdout', action=argparse.BooleanOptionalAction,
+            help='Output peer configuration to stdout')
+    args = parser.parse_args()
+    main(args)

--- a/interactive.py
+++ b/interactive.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import cmd
 import yaml
 import validate_config as validations
 
@@ -33,8 +34,12 @@ class output:
 
     def choices(question, options, status=str(), lines_before=0, lines_after=0):
         output.print(question, lines_after=1)
-        for idx, option in enumerate(options):
-            output.print(f'\t{idx+1}. {option}')
+
+        # https://stackoverflow.com/a/59627245
+        cmd.Cmd().columnize(
+            [f'\t{idx+1}. {option}' for idx, option in enumerate(options)],
+            displaywidth=80
+        )
 
         try:
             return int(output.ask('Selection: '))

--- a/interactive.py
+++ b/interactive.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import yaml
@@ -229,7 +229,7 @@ def main(args):
         peers = [peer]
         output.ok('--- Generated Configuration ---')
         output.print(f'# routers/{router}.yml', lines_after=1)
-        output.print(yaml.dump(peers, sort_keys=False))
+        output.print(yaml.dump(peers, Dumper=IndentDumper, sort_keys=False))
     else:
         # Write YAML to selected router
         peers = load_router_peers(router)

--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::2592
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: nl-dro01.net.h3xco.de
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv6: fe80::118
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: ams.peer.highdef.network
     remote_port: 20207
@@ -26,7 +28,8 @@
   ipv6: fe80::124
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 95.165.102.26
     remote_port: 50694
@@ -37,26 +40,29 @@
   ipv6: fe80::129:c9db
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     public_key: ifW+1tgOE6Ss4cjin/HV/CBTk62NrTZkPXWF0/aAmRU=
-
-- name: VENTILAAR-AMS01
-  asn: 4242422246
-  ipv6: fe80::2246
-  sessions: [ipv6]
-  wireguard:
-    remote_address: ams01.dn42.ventilaar.net
-    remote_port: 30207
-    public_key: 2VgphViJTNqQWlGII40Vfdjw+Uh6t/or1BHOQNDIS2A=
 
 - name: RAOULBROUNS-AMS01
   asn: 4242421612
   ipv6: fe80::5400:04ff:fecb:5ff1
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: dn42bgp.raoulbrouns.nl
     remote_port: 51821
     public_key: wR6/EisJIMiDa0v+akDxBOkAo7tDOLsiIPhQAnEQzVo=
+
+- name: VENTILAAR-AMS01
+  asn: 4242422246
+  ipv6: fe80::2246
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: ams01.dn42.ventilaar.net
+    remote_port: 30207
+    public_key: 2VgphViJTNqQWlGII40Vfdjw+Uh6t/or1BHOQNDIS2A=

--- a/routers/router.atl1.yml
+++ b/routers/router.atl1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::1080:119
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: atl.peer.highdef.network
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv4: 172.22.155.65
   ipv6: fd7e:ad65:45c4::1
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 38.45.67.114
     remote_port: 20207
@@ -24,7 +26,8 @@
 - name: VENTILAAR-ATL04
   asn: 4242422246
   ipv6: fe80::2246
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: atl04.dn42.ventilaar.net
     remote_port: 30207

--- a/routers/router.chi1.yml
+++ b/routers/router.chi1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::113
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: chi.peer.highdef.network
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv6: fe80::3136
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 98.180.237.138
     remote_port: 50207
@@ -27,7 +29,8 @@
   ipv6: fe80::1588
   local_ipv6: fe80::100/64
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us-chi01.dn42.tech9.io
     remote_port: 58438

--- a/routers/router.dal1.yml
+++ b/routers/router.dal1.yml
@@ -4,18 +4,20 @@
   ipv6: fe80::1080:33
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: mci.peer.highdef.network
     remote_port: 20207
     public_key: gTSNP0p+Ok3gaw0mcB1yhuZ2obaoOUxW+jPI2KxGAkc=
 
-- name: JK-NETWORK-DAL  # PeerID: 23206
+- name: JK-NETWORK-DAL
   asn: 4242422717
   ipv6: fe80::2717
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us.vm.whojk.com
     remote_port: 23206
@@ -26,7 +28,8 @@
   ipv6: fe80::2010
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 98.96.28.54
     remote_port: 50207
@@ -38,7 +41,8 @@
   ipv6: fe80::1588
   local_ipv6: fe80::100/64
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us-dal01.dn42.tech9.io
     remote_port: 56736

--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -4,11 +4,24 @@
   ipv6: fe80::100
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: dn42-us-nj01.exabyte.network
     remote_port: 51842
     public_key: rIVfL4TgIRgwGgCZhPST+jR7LLTkMFsCHZgnWpE74GM=
+
+- name: KIOUBIT-US2
+  asn: 4242423914
+  ipv6: fe80::ade0
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: us2.g-load.eu
+    remote_port: 20207
+    public_key: 6Cylr9h1xFduAO+5nyXhFI1XJ0+Sw9jCpCDvcqErF1s=
 
 - name: LUTOMA-NYC
   asn: 64719
@@ -16,41 +29,20 @@
   ipv4: 172.22.119.10
   ipv6: fe80::acab
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 23.95.146.112
     remote_port: 42691
     public_key: SODW7Q2gThSlNEnJrKJHSe8zd4nW8SHjxJuQ2YXyWE0=
-
-- name: KIOUBIT-US2
-  asn: 4242423914
-  ipv6: fe80::ade0
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: us2.g-load.eu
-    remote_port: 20207
-    public_key: 6Cylr9h1xFduAO+5nyXhFI1XJ0+Sw9jCpCDvcqErF1s=
-
-- name: SUNNET-NYC1
-  asn: 4242423088
-  ipv6: fe80::3088:194
-  local_ipv6: fe80::abcd/64
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: 192.3.165.229
-    remote_port: 20207
-    public_key: wAI2D+0GeBnFUqm3xZsfvVlfGQ5iDWI/BykEBbkc62c=
 
 - name: SERNET-US-NYC1
   asn: 4242423947
   ipv6: fe80::3947:7
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us-nyc1.dn42.sherpherd.top
     remote_port: 20207
@@ -61,8 +53,22 @@
   ipv6: fe80::2926
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: router.gcbbs.net
     remote_port: 21845
     public_key: MZHb2cL0jNZyH1uM01ic3ut3cUZEXC+hiJMthR7s0Ww=
+
+- name: SUNNET-NYC1
+  asn: 4242423088
+  ipv6: fe80::3088:194
+  local_ipv6: fe80::abcd/64
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: 192.3.165.229
+    remote_port: 20207
+    public_key: wAI2D+0GeBnFUqm3xZsfvVlfGQ5iDWI/BykEBbkc62c=

--- a/routers/router.fnc1.yml
+++ b/routers/router.fnc1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::1080:34
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sjc.peer.highdef.network
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv6: fe80::ade0
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us3.g-load.eu
     remote_port: 20207
@@ -26,7 +28,8 @@
   ipv6: fe80::1817
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 208.99.48.123
     remote_port: 20207
@@ -37,7 +40,8 @@
   ipv4: 172.21.77.35
   ipv6: fe80::927
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 174.137.51.245
     remote_port: 42496
@@ -49,7 +53,8 @@
   ipv4: 172.22.119.11
   ipv6: fe80::acab
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 198.52.125.186
     remote_port: 42630
@@ -60,7 +65,8 @@
   ipv6: fe80::1580:1
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sfo.dn42.noreinx.me
     remote_port: 20207

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -4,22 +4,48 @@
   ipv6: fe80::117
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: fra.peer.highdef.network
     remote_port: 20207
     public_key: oiSSSOMYxiiM0eQP9p8klwEfNn34hkNNv4S289WUciU=
 
-- name: JK-NETWORK-FRA  # PeerID: 24014
+- name: IMLONGHAO-DE1
+  asn: 4242421888
+  ipv6: fe80::1888
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: de1.dn42.ni.sb
+    remote_port: 20207
+    public_key: k9F2akSTkbA/GiO59PNW/v0D65ioMYD4P1DqeKSL3FM=
+
+- name: JK-NETWORK-FRA
   asn: 4242422717
   ipv6: fe80::2717
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: de.vm.whojk.com
     remote_port: 24014
     public_key: rS+EVSpHhBW7nXv0m/Vw2I/tujwZUEyxZmV51k7Wkzw=
+
+- name: KIOUBIT-DE2
+  asn: 4242423914
+  ipv6: fe80::ade0
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: de2.g-load.eu
+    remote_port: 20207
+    public_key: B1xSG/XTJRLd+GrWDsB06BqnIq8Xud93YVh/LYYYtUY=
 
 - name: LUTOMA-FRA
   asn: 64719
@@ -27,45 +53,36 @@
   ipv4: 172.22.119.1
   ipv6: fe80::acab
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 2603:c020:8001:ed42::42
     remote_port: 43178
     public_key: x8FhufXIjV9KrHcMYzOhhytLF3TFFSAMH7OClTxZxn0=
-
-- name: TECH9_DE-FRA02
-  asn: 4242421588
-  ipv4: 172.20.16.141
-  ipv6: fe80::1588
-  local_ipv6: fe80::100/64
-  multiprotocol: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: de-fra02.dn42.tech9.io
-    remote_port: 55535
-    public_key: MD1EdVe9a0yycUdXCH3A61s3HhlDn17m5d07e4H33S0=
-
-- name: KIOUBIT-DE2
-  asn: 4242423914
-  ipv6: fe80::ade0
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: de2.g-load.eu
-    remote_port: 20207
-    public_key: B1xSG/XTJRLd+GrWDsB06BqnIq8Xud93YVh/LYYYtUY=
 
 - name: PIVIPI-FRA
   asn: 4242420129
   ipv6: fe80::129:93
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: de-fra.inferior.network
     remote_port: 20207
     public_key: u7Pes8qR8m+/4kc4sNTYani90M2MEbaxRsnXKujqik4=
+
+- name: SERNET-DE-FRA1
+  asn: 4242423947
+  ipv6: fe80::3947:6
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: de-fra1.dn42.sherpherd.top
+    remote_port: 20207
+    public_key: KCd+kXNhe48hwOWng77V9E94PszQBqQvJW42c1P+6nk=
 
 - name: SUNNET-FRA1
   asn: 4242423088
@@ -73,30 +90,22 @@
   local_ipv6: fe80::abcd/64
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 2a0f:9441:47:88::2
     remote_port: 20207
     public_key: TWQhJYK+ynNz7A4GMAQSHAyUUKTnAYrBfWTzzjzhAFs=
 
-- name: IMLONGHAO-DE1
-  asn: 4242421888
-  ipv6: fe80::1888
+- name: TECH9_DE-FRA02
+  asn: 4242421588
+  ipv4: 172.20.16.141
+  ipv6: fe80::1588
+  local_ipv6: fe80::100/64
   multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
-    remote_address: de1.dn42.ni.sb
-    remote_port: 20207
-    public_key: k9F2akSTkbA/GiO59PNW/v0D65ioMYD4P1DqeKSL3FM=
-
-- name: SERNET-DE-FRA1
-  asn: 4242423947
-  ipv6: fe80::3947:6
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: de-fra1.dn42.sherpherd.top
-    remote_port: 20207
-    public_key: KCd+kXNhe48hwOWng77V9E94PszQBqQvJW42c1P+6nk=
+    remote_address: de-fra02.dn42.tech9.io
+    remote_port: 55535
+    public_key: MD1EdVe9a0yycUdXCH3A61s3HhlDn17m5d07e4H33S0=

--- a/routers/router.gru1.yml
+++ b/routers/router.gru1.yml
@@ -4,7 +4,8 @@
   ipv4: 172.23.240.161
   ipv6: fe80::3471:5231:161
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 2603:c021:c002:200:c99f:df16:fe23:57b2
     remote_port: 52161
@@ -15,7 +16,8 @@
   ipv6: fe80::1080:32
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sao.peer.highdef.network
     remote_port: 20207

--- a/routers/router.iad1.yml
+++ b/routers/router.iad1.yml
@@ -5,7 +5,8 @@
   ipv6: fe80::1588
   local_ipv6: fe80::100/64
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us-qas01.dn42.tech9.io
     remote_port: 59162
@@ -16,6 +17,7 @@
   ipv6: fe80::1669
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     public_key: 2BEC3CFKpAiIK3wTStbVuHyy894p5g2JLLTajdBsUF8=

--- a/routers/router.lax1.yml
+++ b/routers/router.lax1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::1888
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us2.dn42.ni.sb
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv6: fe80::3947:4
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us-lax1.dn42.sherpherd.top
     remote_port: 20207

--- a/routers/router.lon1.yml
+++ b/routers/router.lon1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::ade0
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: uk1.g-load.eu
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv6: fe80::1604
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: uk1.vm.libecho.top
     remote_port: 20207
@@ -27,7 +29,8 @@
   local_ipv6: fe80::abcd/64
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 2a04:92c7:e:6e4::2
     remote_port: 20207

--- a/routers/router.mad1.yml
+++ b/routers/router.mad1.yml
@@ -1,22 +1,24 @@
 ---
-- name: DP-NETWORKS-PT
-  asn: 4242422096
-  ipv4: 172.23.6.146
-  ipv6: fe80::fafe
-  multiprotocol: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: vpn.diogopassos.pt
-    remote_port: 22097
-    public_key: czJoGDj8855EvO0nwqVLH1Bv/I6quSaD1mddFE408nE=
-
 - name: ARFNET
   asn: 4242423269
   ipv4: 172.20.196.63
   ipv6: fe80::caca
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 2.59.235.35
     remote_port: 51821
     public_key: IgblQAQmXTOGz6Co4lMtucwrxmb9N9i5e1CkfpYiXQA=
+
+- name: DP-NETWORKS-PT
+  asn: 4242422096
+  ipv4: 172.23.6.146
+  ipv6: fe80::fafe
+  multiprotocol: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: vpn.diogopassos.pt
+    remote_port: 22097
+    public_key: czJoGDj8855EvO0nwqVLH1Bv/I6quSaD1mddFE408nE=

--- a/routers/router.mia1.yml
+++ b/routers/router.mia1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::1888
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: us1.dn42.ni.sb
     remote_port: 20207
@@ -13,7 +14,8 @@
 - name: TOMPKEN-SRQ
   asn: 4242421893
   ipv4: 172.23.248.65
-  sessions: [ipv4]
+  sessions:
+    - ipv4
   wireguard:
     remote_address: srq.db42.tompaw.net
     remote_port: 50001

--- a/routers/router.mum1.yml
+++ b/routers/router.mum1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::2174
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: mum1.dn42.4v1.in
     remote_port: 20207

--- a/routers/router.par1.yml
+++ b/routers/router.par1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::cc82
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: par01.fr.dn42.jcx.ovh
     remote_port: 54843
@@ -15,7 +16,8 @@
   ipv6: fe80::ade0
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: fr1.g-load.eu
     remote_port: 20207

--- a/routers/router.sea1.yml
+++ b/routers/router.sea1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::1080:35
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: yvr.peer.highdef.network
     remote_port: 20207
@@ -15,7 +16,8 @@
   ipv6: fe80::1350
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sea.jvav.tech
     remote_port: 20207

--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -4,11 +4,48 @@
   ipv6: fe80::1080:39
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sgp.peer.highdef.network
     remote_port: 20207
     public_key: X3m9VMzZYN4Oe2QUb7DcnmVymwKSLbPUCB5ElD8igjo=
+
+- name: IMLONGHAO-SG1
+  asn: 4242421888
+  ipv6: fe80::1888
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: sg1.dn42.ni.sb
+    remote_port: 20207
+    public_key: vBcYFxMLwcsVScQ0LqkGDEIbbykskatmqWHlPGEUrE8=
+
+- name: LIBECHO-HK1
+  asn: 4242421604
+  ipv6: fe80::1604
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: hk1.vm.libecho.top
+    remote_port: 20207
+    public_key: hQgRGnAP4xBHym+R/jf7ScjGbBDz5RXi5gF6CF7RiWg=
+
+- name: SERNET-HK1
+  asn: 4242423947
+  ipv6: fe80::3947:1
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: 47.242.165.101
+    remote_port: 20207
+    public_key: Lz/SPcnKfbp4Z6LW7gysFxhyJXfyoett18r3kvlZcBY=
 
 - name: TECH9_SG-SIN01
   asn: 4242421588
@@ -16,50 +53,19 @@
   ipv6: fe80::1588
   local_ipv6: fe80::100/64
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sg-sin01.dn42.tech9.io
     remote_port: 52795
     public_key: 4qLIJ9zpc/Xgvy+uo90rGso75cSrT2F5tBEv+6aqDkY=
 
-- name: LIBECHO-HK1
-  asn: 4242421604
-  ipv6: fe80::1604
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: hk1.vm.libecho.top
-    remote_port: 20207
-    public_key: hQgRGnAP4xBHym+R/jf7ScjGbBDz5RXi5gF6CF7RiWg=
-
-- name: IMLONGHAO-SG1
-  asn: 4242421888
-  ipv6: fe80::1888
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: sg1.dn42.ni.sb
-    remote_port: 20207
-    public_key: vBcYFxMLwcsVScQ0LqkGDEIbbykskatmqWHlPGEUrE8=
-
 - name: VENTILAAR-SIN05
   asn: 4242422246
   ipv6: fe80::2246
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: sin05.dn42.ventilaar.net
     remote_port: 30207
     public_key: h6h4yzNS/jMPvrNzD+er1zoAPcp7pOlPuWtnemrOZxQ=
-
-- name: SERNET-HK1
-  asn: 4242423947
-  ipv6: fe80::3947:1
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: 47.242.165.101
-    remote_port: 20207
-    public_key: Lz/SPcnKfbp4Z6LW7gysFxhyJXfyoett18r3kvlZcBY=

--- a/routers/router.sto1.yml
+++ b/routers/router.sto1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::1525
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: se1.alemal.se
     remote_port: 50207

--- a/routers/router.syd1.yml
+++ b/routers/router.syd1.yml
@@ -4,51 +4,57 @@
   ipv6: fe80::1080:125
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: syd.peer.highdef.network
     remote_port: 20207
     public_key: Xk9wCuwp3zK4WflTeAKBIjgIlr3+qUwIFCkF2uMyyF8=
-
-- name: IMLONGHAO-AU1
-  asn: 4242421888
-  ipv6: fe80::1888
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: au1.dn42.ni.sb
-    remote_port: 20207
-    public_key: Syd/jYnhMvDrvp1POVCLuAlagWjV9X/A5DCbEBpdFBc=
 
 - name: HPG-AU
   asn: 4242420965
   ipv6: fe80::101
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: au-sydney.dn42.hpg.nz
     remote_port: 20207
     public_key: cQk3rnAfDl0XbRHBmedAP79MEgm0N28XDsWMMGyDOjk=
 
-- name: LINE-NZ
-  asn: 4242429999
-  ipv4: 172.20.160.1
-  ipv6: fe80::e5c4:1636:647e:68ec
-  sessions: [ipv4, ipv6]
+- name: IMLONGHAO-AU1
+  asn: 4242421888
+  ipv6: fe80::1888
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
   wireguard:
-    remote_address: wlg1.dn42.line.nz
-    remote_port: 13235
-    public_key: 5cQWNmR+aOw68grAh4wFuMOcknEEThCOwCN652R6MRM=
+    remote_address: au1.dn42.ni.sb
+    remote_port: 20207
+    public_key: Syd/jYnhMvDrvp1POVCLuAlagWjV9X/A5DCbEBpdFBc=
 
 - name: JACK-SYD01
   asn: 4242422971
   ipv4: 172.23.159.65
   ipv6: fe80::2971:1
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: syd01.dn42.jackscott.xyz
     remote_port: 50207
     public_key: 5b/QZxY2406E+it3M7k1r7jOzs7a0sogz47faHfCblc=
+
+- name: LINE-NZ
+  asn: 4242429999
+  ipv4: 172.20.160.1
+  ipv6: fe80::e5c4:1636:647e:68ec
+  sessions:
+    - ipv4
+    - ipv6
+  wireguard:
+    remote_address: wlg1.dn42.line.nz
+    remote_port: 13235
+    public_key: 5cQWNmR+aOw68grAh4wFuMOcknEEThCOwCN652R6MRM=

--- a/routers/router.tor1.yml
+++ b/routers/router.tor1.yml
@@ -4,7 +4,8 @@
   ipv6: fe80::ca75
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 159.203.6.197
     remote_port: 51237
@@ -15,7 +16,8 @@
   ipv6: fe80::123
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: ymq.peer.highdef.network
     remote_port: 20207
@@ -24,7 +26,8 @@
 - name: TOZTECH-CA
   asn: 4242421812
   ipv4: 172.23.34.254
-  sessions: [ipv4]
+  sessions:
+    - ipv4
   wireguard:
     remote_address: dn42.toztech.com
     remote_port: 20207

--- a/routers/router.tyo1.yml
+++ b/routers/router.tyo1.yml
@@ -4,18 +4,20 @@
   ipv6: fe80::124
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: tyo.peer.highdef.network
     remote_port: 20207
     public_key: iJXjwJGGrUTQy/P3OXmZ5lM4cjrDAd9K+vonZVUZjxY=
 
-- name: JK-NETWORK-TYO  # PeerID: 23709
+- name: JK-NETWORK-TYO
   asn: 4242422717
   ipv6: fe80::2717
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: jp.vm.whojk.com
     remote_port: 23709
@@ -26,11 +28,24 @@
   ipv6: fe80::1772
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 45.39.70.216
     remote_port: 40207
     public_key: 3QqjBrblQr+QreDdghxr5dc8Hv9uxG5Px6Zc9cCbNQQ=
+
+- name: SERNET-KR-SEL1
+  asn: 4242423947
+  ipv6: fe80::3947:5
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: 158.247.200.238
+    remote_port: 20207
+    public_key: 8yPUQU9Vg6rmZ03F+JyQjGUzIIZnt8AA6xqTmbBxClg=
 
 - name: SUNNET-TYO1
   asn: 4242423088
@@ -38,7 +53,8 @@
   local_ipv6: fe80::abcd/64
   multiprotocol: true
   extended_nexthop: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: 45.66.128.152
     remote_port: 20207
@@ -50,19 +66,9 @@
   ipv6: fe80::1588
   local_ipv6: fe80::100/64
   multiprotocol: true
-  sessions: [ipv6]
+  sessions:
+    - ipv6
   wireguard:
     remote_address: jp-tyo01.dn42.tech9.io
     remote_port: 55032
     public_key: unTYSat5YjkY+BY31Q9xLSfFhTUBvn3CiDCSZxbINVM=
-
-- name: SERNET-KR-SEL1
-  asn: 4242423947
-  ipv6: fe80::3947:5
-  multiprotocol: true
-  extended_nexthop: true
-  sessions: [ipv6]
-  wireguard:
-    remote_address: 158.247.200.238
-    remote_port: 20207
-    public_key: 8yPUQU9Vg6rmZ03F+JyQjGUzIIZnt8AA6xqTmbBxClg=

--- a/validate_config.py
+++ b/validate_config.py
@@ -159,8 +159,9 @@ def validate_boolean(attrib):
 def validate_name(name):
     # Validate format: must be all uppercase, start with letter,
     # only '-' and '_' separators allowed
-    if not re.match("^[A-Z][A-Z0-9-_]+$", name):
-        return f"name: '{name}' is not in a valid format"
+    required_format = "^[A-Z][A-Z0-9-_]+$"
+    if not re.match(required_format, name):
+        return f"name: '{name}' is not in a valid format, must match {required_format}"
 
 
 def validate_ip(addr, af, attrib):


### PR DESCRIPTION
Addresses #59

Interactive script for new peerings

```
-> ./interactive.py

What router would you like to peer at?

	1. router.ams1  	8. router.fra1   	15. router.mia1  	22. router.sto1
	2. router.atl1  	9. router.gru1   	16. router.mil1  	23. router.syd1
	3. router.cgk1  	10. router.iad1  	17. router.mum1  	24. router.tor1
	4. router.chi1  	11. router.lax1  	18. router.osa1  	25. router.tyo1
	5. router.dal1  	12. router.lon1  	19. router.par1
	6. router.ewr1  	13. router.maa1  	20. router.sea1
	7. router.fnc1  	14. router.mad1  	21. router.sin1

Selection: 7

Peer Name: YZGUY-FNC

DN42 ASN: 4242421669

Which BGP peering type are you requesting?

	1. Multi-protocol (IPv4 and IPv6) with Extended Nexthop capability (preferred)
	2. Multi-protocol (IPv4 and IPv6)
	3. IPv4 and IPv6 (separate sessions)
	4. IPv4 ONLY
	5. IPv6 ONLY

Selection: 1

IPv6 tunnel address (Link-local preferred, /64 assumed unless specified): fe80::1669

Wireguard Endpoint: rtr1.mkc1.as199344.net

Wireguard Port: 20207

Wireguard Public Key: 2BEC3CFKpAiIK3wTStbVuHyy894p5g2JLLTajdBsUF8=

Validating peer: YZGUY-FNC... ok 

Successfully saved peer to router.fnc1.yml
```

Alternatively, if you run `./interactive.py --stdout` it will output to STDOUT instead of write to file

```
--- Generated Configuration ---

# routers/router.fnc1.yml

- name: YZGUY-FNC
  asn: 4242421669
  ipv6: fe80::1669
  multiprotocol: true
  extended_nexthop: true
  sessions:
    - ipv6
  wireguard:
    remote_address: rtr1.mkc1.as199344.net
    remote_port: 20207
    public_key: 2BEC3CFKpAiIK3wTStbVuHyy894p5g2JLLTajdBsUF8=
```