### PR TITLE
feat(ams1): Add MARSHALL-AS peering

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -21,6 +21,17 @@
     remote_port: 20207
     public_key: EdWVXZMdujdL/jX5FZDjkPQPVaLoWt4C8FowNRbuaTU=
 
+- name: MARSHALL-AMS1
+  asn: 4242420694
+  ipv6: fe80::124
+  multiprotocol: true
+  extended_nexthop: true
+  sessions: [ipv6]
+  wireguard:
+    remote_address: 95.165.102.26
+    remote_port: 50694
+    public_key: kNcRVZ3Ohke+AG3Fcel7FXHeVjj/AcfLBCYOyxrFBAs=
+
 - name: PIVIPI-AMS
   asn: 4242420129
   ipv6: fe80::129:c9db


### PR DESCRIPTION
Add `MARSHALL-AS` peering to `router.ams1` as requested via Google form.