### PR TITLE
chore(ams1): update MARSHAL-AS peering address

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -25,7 +25,7 @@
 
 - name: MARSHALL-AMS1
   asn: 4242420694
-  ipv6: fe80::124
+  ipv6: fc00:0:0:20::1/64
   multiprotocol: true
   extended_nexthop: true
   sessions:

--- a/validate_config.py
+++ b/validate_config.py
@@ -179,8 +179,8 @@ def validate_ip(addr, af, attrib):
     if af == "ipv6":
         if ip.version != 6:
             return f"{attrib}: '{addr}' is not an IPv6 address"
-        if not ip.is_link_local and not ip.subnet_of(ipaddress.ip_network("fd00::/8")):
-            return f"{attrib}: '{addr}' is not within fe80::/10 or fd00::/8"
+        if not ip.is_link_local and not ip.subnet_of(ipaddress.ip_network("fc00::/7")):
+            return f"{attrib}: '{addr}' is not within fe80::/10 or fc00::/7"
 
 
 def validate_sessions(sessions, peer):


### PR DESCRIPTION
Use IPv6 ULA on p2p wireguard link for MARSHAL-AS.