### PR TITLE
fix(starstorm-nyc1): fix incorrect extended nexthop capability

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -50,9 +50,9 @@
 
 - name: STARSTORM-NYC1
   asn: 4242420275
+  ipv4: 172.20.159.98
   ipv6: fe80::2926
   multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:


### PR DESCRIPTION
Peer STARSTORM-NYC1 on `router.ewr1` was discovered not to be sending extended nexthop capability and causing route flap issues between peers.

```
BGP neighbor is fe80::2926, remote AS 4242420275, local AS 4242420207, external link
  Local Role: undefined
  Remote Role: undefined
 Description: STARSTORM-NYC1
[...]
  Neighbor capabilities:
    4 Byte AS: advertised and received
    Extended Message: advertised and received
    AddPath:
      IPv4 Unicast: RX advertised
      IPv6 Unicast: RX advertised
    Extended nexthop: advertised
    [...]
```

This PR corrects the session to insert a static IPv4 route for their tunnel endpoint and use a single IPv6 session for both IPv4 and IPv6 address-families without using extended-nexthop.