### PR TITLE
chore(dal1): use HIGHDEF AS4242421080 DAL endpoint

### DIFF
--- a/routers/router.dal1.yml
+++ b/routers/router.dal1.yml
@@ -9,7 +9,7 @@
   wireguard:
     public_key: ZqQUTDUXPHW0Q94CO1irTe+TnVnrRAnlf5WmmFGXp3w=
 
-- name: HIGHDEF-MCI
+- name: HIGHDEF-DAL
   asn: 4242421080
   ipv6: fe80::1080:33
   multiprotocol: true
@@ -17,7 +17,7 @@
   sessions:
     - ipv6
   wireguard:
-    remote_address: mci.peer.highdef.network
+    remote_address: dal.peer.highdef.network
     remote_port: 20207
     public_key: gTSNP0p+Ok3gaw0mcB1yhuZ2obaoOUxW+jPI2KxGAkc=
 


### PR DESCRIPTION
HIGHDEF no longer has a MCI endpoint, our peering was moved to their DAL endpoint (https://github.com/jlu5/ansible-dn42/blob/1ca3875599ed181cf897fa1b16b612931c5df369/roles/config-wireguard/config/dal.yml#L39-L44)