### PR TITLE
chore: migrate HIGHDEF peering from ATL1 to MIA1

### DIFF
--- a/routers/router.atl1.yml
+++ b/routers/router.atl1.yml
@@ -1,16 +1,4 @@
 ---
-- name: HIGHDEF-ATL
-  asn: 4242421080
-  ipv6: fe80::1080:119
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: atl.peer.highdef.network
-    remote_port: 20207
-    public_key: gbhhdvAIHVuv5e+tIG/m9T9fDaGoAGVgSUHq+rKTLyY=
-
 - name: VENTILAAR-ATL04
   asn: 4242422246
   ipv6: fe80::2246

--- a/routers/router.mia1.yml
+++ b/routers/router.mia1.yml
@@ -1,4 +1,16 @@
 ---
+- name: HIGHDEF-TPA
+  asn: 4242421080
+  ipv6: fe80::1080:119
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: tpa.peer.highdef.network
+    remote_port: 20207
+    public_key: gbhhdvAIHVuv5e+tIG/m9T9fDaGoAGVgSUHq+rKTLyY=
+
 - name: IMLONGHAO-US1
   asn: 4242421888
   ipv6: fe80::1888


### PR DESCRIPTION
Noticed earlier that some of the highdef peerings don't go to where they originally went, eg ATL1 to ATL.

The ATL1 peering now goes to their Tampa (TPA) node

```
-> dig atl.peer.highdef.network +short
tpa.peer.highdef.network.
158.51.125.4
```

Looking at the latency between ATL1 and TPA, and MIA1 and TPA it's much better going to MIA1 (16ms vs 8ms)

ATL1 <> TPA

```
yzguy@router.atl1:~$ ping tpa.peer.highdef.network count 1
PING tpa.peer.highdef.network(2606:65c0:20:97:ae8:3d00:92c9:abdf.hostodo.com (2606:65c0:20:97:ae8:3d00:92c9:abdf)) 56 data bytes
64 bytes from 2606:65c0:20:97:ae8:3d00:92c9:abdf.hostodo.com (2606:65c0:20:97:ae8:3d00:92c9:abdf): icmp_seq=1 ttl=53 time=16.0 ms

--- tpa.peer.highdef.network ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 15.963/15.963/15.963/0.000 ms
```

MIA1 <> TPA

```
yzguy@router.mia1:~$ ping tpa.peer.highdef.network count 1
PING tpa.peer.highdef.network(2606:65c0:20:97:ae8:3d00:92c9:abdf.hostodo.com (2606:65c0:20:97:ae8:3d00:92c9:abdf)) 56 data bytes
64 bytes from 2606:65c0:20:97:ae8:3d00:92c9:abdf.hostodo.com (2606:65c0:20:97:ae8:3d00:92c9:abdf): icmp_seq=1 ttl=49 time=7.69 ms

--- tpa.peer.highdef.network ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 7.693/7.693/7.693/0.000 ms
```

Therefore we will migrate the peering from ATL1 to MIA1

Opened a commit to update it on their side as well https://github.com/jlu5/ansible-dn42/pull/29