### PR TITLE
feat: dispatch config on pull_request_target

### DIFF
--- a/.github/workflows/dispatch_config.yml
+++ b/.github/workflows/dispatch_config.yml
@@ -1,9 +1,11 @@
 name: Dispatch Configuration
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [closed]
+    paths:
+      - 'routers/*.yml'
 
 jobs:
   set-limit:


### PR DESCRIPTION
When users submit a PR from a fork, we review + merge. However the Actions fail because they don't have permissions to secrets, etc because the use of `on: pull_request` is read-only, and therefore cannot make changes to the upstream repo

[pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) was created to address this, but has some security implications, as it has access to secrets and can make changes to the upstream

I believe the security concerns are mitigated based on:
* The action will run in the context of the base of the pull request rather than the context of the merge commit.
* It only runs after a pull request is closed and it was a merge (which can only be done by us after reviewing)
* It only runs on changes to `*.yml` files in `routers/*` further limiting when this can run
* We do not take user input nor read anything a user may have manipulated
  * We gather changed files in the pull request and kick off a dispatch + comment based on that

