### PR TITLE
refactor: Remove MP-BGP ext-nh on some COLBY AS4242422558

### DIFF
--- a/routers/router.chi1.yml
+++ b/routers/router.chi1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-CHI1
   asn: 4242422558
   ipv6: fe80::2558:6005
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-FSN1
   asn: 4242422558
   ipv6: fe80::2558:6009
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.lax1.yml
+++ b/routers/router.lax1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-LAX1
   asn: 4242422558
   ipv6: fe80::2558:7
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.mia1.yml
+++ b/routers/router.mia1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-JAX1
   asn: 4242422558
   ipv6: fe80::2558:6006
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.par1.yml
+++ b/routers/router.par1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-GRA1
   asn: 4242422558
   ipv6: fe80::2558:6008
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-SIN1
   asn: 4242422558
   ipv6: fe80::2558:6003
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.sto1.yml
+++ b/routers/router.sto1.yml
@@ -26,8 +26,6 @@
 - name: COLBY-HEL1
   asn: 4242422558
   ipv6: fe80::2558:6010
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.tor1.yml
+++ b/routers/router.tor1.yml
@@ -2,8 +2,6 @@
 - name: BOOTL0ADER-TOR
   asn: 4242421838
   ipv6: fe80::ca75
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:

--- a/routers/router.tyo1.yml
+++ b/routers/router.tyo1.yml
@@ -2,8 +2,6 @@
 - name: COLBY-TYO1
   asn: 4242422558
   ipv6: fe80::2558:6002
-  multiprotocol: true
-  extended_nexthop: true
   sessions:
     - ipv6
   wireguard:


### PR DESCRIPTION
It was [mentioned](https://github.com/Colbyjdx/dn42-ansible/pull/1#issuecomment-2103606066) that some nodes are not IPv4 capable, therefore we should clean up the MP-BGP w/ ext-nh config for these peerings