### PR TITLE
feat: output ASN info from registry in interactive

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -24,10 +24,28 @@ class Registry(object):
         resp.raise_for_status()
         return resp
 
+    def _transform_response(self, resp):
+        '''
+        Transform response from a list of lists
+        to a dictionary
+
+        [['as-name', 'ABC-AS'], ['descr', 'ABCs AS']]
+
+        to
+
+        {'as-name': 'ABC-AS', 'descr': 'ABCs AS'}
+        '''
+        data = {}
+        for elem in resp:
+            data[elem[0]] = elem[1]
+
+        return data
+
     def asns(self):
         path = '/aut-num'
         return self._request('GET', path).json()['aut-num']
 
     def asn(self, asn):
-        path = f'/aut-num/AS{asn}'
-        return self._request('GET', path).json()
+        path = f'/aut-num/AS{asn}?raw'
+        resp = self._request('GET', path).json()[f'aut-num/AS{asn}']
+        return self._transform_response(resp)


### PR DESCRIPTION
* Add simple `--registry` flag to enable outputting data from the registry after data is entered.
* After getting the ASN from the user, do a quick API call to to the registry to get data about the ASN and output it

```
-> python interactive.py --registry
What router would you like to peer at?

	1. router.ams1  	8. router.fra1   	15. router.mia1  	22. router.sto1
	2. router.atl1  	9. router.gru1   	16. router.mil1  	23. router.syd1
	3. router.cgk1  	10. router.iad1  	17. router.mum1  	24. router.tor1
	4. router.chi1  	11. router.lax1  	18. router.osa1  	25. router.tyo1
	5. router.dal1  	12. router.lon1  	19. router.par1
	6. router.ewr1  	13. router.maa1  	20. router.sea1
	7. router.fnc1  	14. router.mad1  	21. router.sin1

Selection: 1

DN42 ASN: 4242421882

AS-NAME:	XENO-AS
Description:	Xenot AS

Peer Name:
```

This is mostly helpful for us when we enter these from Google Form submission data to come up with a peer name. If the flag is not specified it will continue to behave as it did before
