### PR TITLE
fix: handle missing asn fields from registry

### DIFF
--- a/interactive.py
+++ b/interactive.py
@@ -111,8 +111,8 @@ def main(args):
     if args.registry:
         r_asn = registry.asn(asn)
         output.table({
-            'AS-NAME': r_asn['as-name'],
-            'Description': r_asn['descr']
+            'AS-NAME': r_asn.get('as-name', ''),
+            'Description': r_asn.get('descr', '')
         }, status=output.OK)
 
     # Name


### PR DESCRIPTION
Just some testing after and ran into an error because a peer didn't have a 'description' field in their ASN registry entry

```
DN42 ASN: 4242422246
Traceback (most recent call last):
  File "/workspaces/dn42-peers/interactive.py", line 268, in <module>
    main(args)
  File "/workspaces/dn42-peers/interactive.py", line 115, in main
    'Description': r_asn['descr']
                   ~~~~~^^^^^^^^^
```

Quick just to look for if the key exists in the response and provide a default if not