### PR TITLE
feat: add basic devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+	"postCreateCommand": "pip3 install --user -r requirements.txt"
+}


### PR DESCRIPTION
https://medium.com/marvelous-mlops/how-to-start-with-dev-containers-1e92bf0e0f78

Add a basic devcontainer configuration that uses 3.12 Python image, and will install all the requirements needed for the registry automatically

This allows us/users to just launch an dev environment easily without installing anything to our system