### PR TITLE
chore: remove H3XNET-RED-NL

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -11,18 +11,6 @@
     remote_port: 20207
     public_key: aEnSuSUB3ZCrryPAIJxBtH6ZcNgCSeW+dMEceEbiflo=
 
-- name: H3XNET-RED-NL
-  asn: 4242422592
-  ipv6: fe80::2592
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: nl-dro01.net.h3xco.de
-    remote_port: 20207
-    public_key: HWjDZhdwgM6BPXDFmZH1+PskdvnP87EpazZUnV6cwwk=
-
 - name: HIGHDEF-AMS
   asn: 4242421080
   ipv6: fe80::118


### PR DESCRIPTION
Remove peer `H3XNET-RED-NL` (AS 4242422592) from `router.ams1`

Their DNS record is `NXDOMAIN` and the peer has been down for >2 weeks:

```
$ show bgp vrf DN42 neighbors fe80::2592 | grep -A 1 Connections
  Connections established 0; dropped 0
  Last reset 02w0d13h,   Waiting for peer OPEN (n/a)
```