### PR TITLE
feat: add simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+VENVDIR ?= venv
+VENV ?= $(VENVDIR)/bin
+VENV_MARKER := .makefile_venv
+PY := python3
+
+default: peering
+
+.PHONY: venv
+venv: $(VENVDIR)/$(VENV_MARKER)
+
+.PHONY: venv-clean
+venv-clean:
+	-rm -rf "$(VENVDIR)"
+
+$(VENV):
+	$(PY) -m venv $(VENVDIR)
+
+$(VENVDIR)/$(VENV_MARKER): requirements.txt | $(VENV)
+	$(VENV)/pip install -r requirements.txt
+	touch $(VENVDIR)/$(VENV_MARKER)
+
+SHELL:=/bin/bash
+
+##
+# TASKS
+##
+
+.PHONY: peering
+peering: venv  ## make peering # Interactively create a new peerng
+	@python interactive.py
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -30,22 +30,14 @@ You can [click here](https://forms.gle/rt9YZ8AoFfX5YmE8A) to submit a peering re
     cd dn42-peers
     ```
 
-2. Install dependencies
-
-    ```
-    python -m venv venv
-    source venv/bin/activate
-    pip install -r requirements.txt
-    ```
-
-2. Run the `interactive.py` script and provide the requested information
+2. Run the `Makefile` target and provide the requested information
     * Alternatively, you can manually update the appropriate [router](routers/) with your peering information
 
     ```
-    python interactive.py
+    make peering
     ```
 
-3. Create a PR
+3. Create a pull request
 
     ```
     git checkout -b AS123456789_LON1


### PR DESCRIPTION
Add simple Makefile to simplify use for peering requests.

Now all a user will need to do is clone the repository and type `make peering` or just `make` to have all Python dependencies installed and prompted for peering information.