### PR TITLE
fix: ensure makefile task switches to venv before execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SHELL:=/bin/bash
 
 .PHONY: peering
 peering: venv  ## make peering # Interactively create a new peerng
-	@python interactive.py
+	@. venv/bin/activate; python interactive.py
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
The Makefile `peering` task was not switching to the Python virtual environment before running. 

This updates the task to activate the python environment before running the script.