### PR TITLE
chore: re-sort peers alphabetically

### DIFF
--- a/routers/router.lon1.yml
+++ b/routers/router.lon1.yml
@@ -1,4 +1,16 @@
 ---
+- name: BITRAF-TRYGVIS-LON1
+  asn: 4242423538
+  ipv6: fe80::621b:7ccf:ff44:c42c
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: lon1.dn42.trygvis.io
+    remote_port: 51009
+    public_key: x/cvEG6uyatJEao1ob2aPGi7QGqY+2ShdtB/FTGlmAs=
+
 - name: CDUBS-LON
   asn: 4242420566
   ipv6: fe80::566
@@ -46,18 +58,6 @@
     remote_address: uk1.vm.libecho.top
     remote_port: 20207
     public_key: 9U407vEN9S4jZ+MEEFYnYtMpb6H6VyQVMgJIK6oDUVo=
-
-- name: BITRAF-TRYGVIS-LON1
-  asn: 4242423538
-  ipv6: fe80::621b:7ccf:ff44:c42c
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: lon1.dn42.trygvis.io
-    remote_port: 51009
-    public_key: x/cvEG6uyatJEao1ob2aPGi7QGqY+2ShdtB/FTGlmAs=
 
 - name: SFS-UK
   asn: 4242421780

--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -1,4 +1,14 @@
 ---
+- name: CMCC-HK
+  asn: 4242421686
+  ipv6: fe80::1686
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    public_key: ocG/0wXtmuXA9OF5pMVolBIsFfE1K3JILX3MC3J5pGI=
+
 - name: COLBY-SIN1
   asn: 4242422558
   ipv6: fe80::2558:6003
@@ -79,13 +89,3 @@
     remote_address: sin05.dn42.ventilaar.net
     remote_port: 30207
     public_key: h6h4yzNS/jMPvrNzD+er1zoAPcp7pOlPuWtnemrOZxQ=
-
-- name: CMCC-HK
-  asn: 4242421686
-  ipv6: fe80::1686
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    public_key: ocG/0wXtmuXA9OF5pMVolBIsFfE1K3JILX3MC3J5pGI=


### PR DESCRIPTION
Quick re-sorting of peers to be in alphabetical order

```python
#!/usr/bin/env python

import yaml

from interactive import load_router_peers, save_router_peers
from pathlib import Path
from os import listdir

routers = sorted([Path(router).stem for router in listdir('routers')])

for router in routers:
    peers = load_router_peers(router)
    save_router_peers(router, peers)
```