### PR TITLE
feat: add 'validate' target to Makefile [skip ci]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,9 @@ SHELL:=/bin/bash
 peering: venv  ## make peering # Interactively create a new peerng
 	@. venv/bin/activate; python interactive.py
 
+.PHONY: validate
+validate: venv  ## make validate # Validate the peering configurations
+	@. venv/bin/activate; python validate_config.py
+
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR adds aMakefile target to kick off the validation process:

`make validate`

