### PR TITLE
fix: request IPv4 and IPv6 tunnel address when using MP-BGP

### DIFF
--- a/interactive.py
+++ b/interactive.py
@@ -184,10 +184,8 @@ def main(args):
     # Multi-protocol (IPv4 and IPv6)
     elif peering_type == 'mp-bgp':
         session = session_address_family()
-        if 'ipv4' in session:
-            ipv4_tunnel_address()
-        if 'ipv6' in session:
-            ipv6_tunnel_address()
+        ipv4_tunnel_address()
+        ipv6_tunnel_address()
         peer['multiprotocol'] = True
         peer['sessions'] = session
 


### PR DESCRIPTION
Noticed when submitting #155 

When selecting `Multi-protocol (IPv4 and IPv6)`, the previous logic was to request what address family the BGP session would be and depending on that then ask the user their tunnel address for that address family only. In the case of `Multi-protocol (IPv4 and IPv6)`, the session will happen over one of the address family, but we still need both the IPv4 and IPv6 tunnel addresses from the user

Previous behavior

```
Which BGP peering type are you requesting?

	1. Multi-protocol (IPv4 and IPv6) with Extended Nexthop capability (preferred)
	2. Multi-protocol (IPv4 and IPv6)
	3. IPv4 and IPv6 (separate sessions)
	4. IPv4 ONLY
	5. IPv6 ONLY

Selection: 2

Session Address Family (ipv4, ipv6): ipv6

IPv6 tunnel address (Link-local preferred, /64 assumed unless specified): fe80::2608
```

New behavior

```
Which BGP peering type are you requesting?

	1. Multi-protocol (IPv4 and IPv6) with Extended Nexthop capability (preferred)
	2. Multi-protocol (IPv4 and IPv6)
	3. IPv4 and IPv6 (separate sessions)
	4. IPv4 ONLY
	5. IPv6 ONLY

Selection: 2

Session Address Family (ipv4, ipv6): ipv6

IPv4 tunnel address: 172.21.105.1

IPv6 tunnel address (Link-local preferred, /64 assumed unless specified): fe80::2608
```