### PR TITLE
feat: use data from routedbits nodes.json in interactive

### DIFF
--- a/interactive.py
+++ b/interactive.py
@@ -8,6 +8,7 @@ import validate_config as validations
 from os import listdir
 from pathlib import Path
 from registry import Registry
+from routedbits import RoutedBits
 from validate_config import validate
 
 class output:
@@ -84,15 +85,16 @@ def save_router_peers(router, peers):
 def main(args):
     peer = {}
     registry = Registry()
+    nodes = RoutedBits().nodes(minimal=True)
 
     # Router
     router = None
     while True:
-        question = 'What router would you like to peer at?'
-        routers = sorted([Path(router).stem for router in listdir('routers')])
+        question = 'Which RoutedBits endpoint would you like to peer with?'
+        endpoints = [f"{node['city']} ({node['name'].upper()})" for node in nodes]
 
         try:
-            router = routers[output.choices(question, routers)-1]
+            router = nodes[output.choices(question, endpoints)-1]['hostname']
             break
         except (IndexError, TypeError, ValueError):
             output.fail('ERROR: Not a valid selection, try again')

--- a/routedbits.py
+++ b/routedbits.py
@@ -1,0 +1,58 @@
+#
+#
+#
+
+from requests import Session
+
+
+class RoutedBitsNotFound(Exception):
+    def __init__(self):
+        super().__init__('Not Found')
+
+class RoutedBitsTooManyArguments(Exception):
+    def __init__(self):
+        super().__init__('Too many arguments')
+
+
+class RoutedBits(object):
+    BASE = 'https://dn42.routedbits.com'
+
+    def __init__(self):
+        self._session = Session()
+
+    def _request(self, method, path, params=None, data=None):
+        url = f'{self.BASE}{path}'
+        resp = self._session.request(method, url, params=params, json=data)
+        if resp.status_code == 404:
+            raise RoutedBitsNotFound()
+        resp.raise_for_status()
+        return resp
+
+    def nodes(self, minimal=False, sort_by='city'):
+        path = '/nodes.json'
+        resp = self._request('GET', path).json()['regions']
+
+        nodes = resp
+        if minimal:
+            nodes = []
+            for region in resp:
+                nodes.extend(region['sites'])
+            nodes = sorted(nodes, key=lambda node: node[sort_by])
+
+        return nodes
+
+    def node(self, hostname=None, name=None):
+        if hostname and name:
+            raise RoutedBitsTooManyArguments()
+
+        nodes = self.nodes(minimal=True)
+        for node in nodes:
+            if hostname:
+                if node['hostname'] == hostname:
+                    return node
+
+            if name:
+                if node['name'] == name:
+                    return node
+
+        raise RoutedBitsNotFound()


### PR DESCRIPTION
Use the https://dn42.routedbits.com/nodes.json endpoint to get extra to make the user experience better, in particular we use the City name instead of the router name when displaying the options

```
-> python interactive.py
Which RoutedBits endpoint would you like to peer with?

	1. Amsterdam, NL (AMS1)         	14. Miami, FL, US (MIA1)
	2. Ashburn, VA, US (IAD1)       	15. Milan, IT (MIL1)
	3. Atlanta, GA, US (ATL1)       	16. Mumbai, IN (MUM1)
	4. Chennai, IN (MAA1)           	17. Newark, NJ, US (EWR1)
	5. Chicago, IL, US (CHI1)       	18. Osaka, JP (OSA1)
	6. Dallas, TX, US (DAL1)        	19. Paris, FR (PAR1)
	7. Frankfurt, DE (FRA1)         	20. Sao Paulo, BR (GRU1)
	8. Fremont, CA, US (FNC1)       	21. Seattle, WA, US (SEA1)
	9. Jakarta, ID (CGK1)           	22. Singapore, SG (SIN1)
	10. London, UK (LON1)           	23. Stockholm, SE (STO1)
	11. Los Angeles, CA, US (LAX1)  	24. Sydney, AU (SYD1)
	12. Madrid, ES (MAD1)           	25. Tokyo, JP (TYO1)
	13. Melbourne, AU (MEL1)        	26. Toronto, ON, CA (TOR1)
```
