### PR TITLE
feat: handle wireguard remote_address validation for IPv4 only node

### DIFF
--- a/routers/router.sea1.yml
+++ b/routers/router.sea1.yml
@@ -1,16 +1,4 @@
 ---
-- name: LUKASBECKERIT-YXE
-  asn: 4242423372
-  ipv6: fe80::3372/64
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: yxe.beckerit.cc
-    remote_port: 20207
-    public_key: okxcWYCduqtZfKfZVTLc4cCMxOXBYvUEkl8OLzxe3hQ=
-
 - name: CDUBS-SEA
   asn: 4242420566
   ipv6: fe80::566
@@ -58,6 +46,18 @@
     remote_address: sea.jvav.tech
     remote_port: 20207
     public_key: VCYdDHIKBDfHe+drn2CG6pw56HBzDeoRt6wAx6GUg0Y=
+
+- name: LUKASBECKERIT-YXE
+  asn: 4242423372
+  ipv6: fe80::3372/64
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: yxe.beckerit.cc
+    remote_port: 20207
+    public_key: okxcWYCduqtZfKfZVTLc4cCMxOXBYvUEkl8OLzxe3hQ=
 
 - name: MIKEHU44
   asn: 4242420464

--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -55,6 +55,18 @@
     remote_port: 20207
     public_key: hQgRGnAP4xBHym+R/jf7ScjGbBDz5RXi5gF6CF7RiWg=
 
+- name: MOECHS-HK01
+  asn: 4242421522
+  ipv6: fe80::1522
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: hk01.zapto.org
+    remote_port: 23009
+    public_key: McL3+qMK+YrKJHQB5GvDUcUKecsLPaDMFNzlVjjSdDo=
+
 - name: SERNET-HK1
   asn: 4242423947
   ipv6: fe80::3947:1
@@ -89,15 +101,3 @@
     remote_address: sin05.dn42.ventilaar.net
     remote_port: 30207
     public_key: h6h4yzNS/jMPvrNzD+er1zoAPcp7pOlPuWtnemrOZxQ=
-
-- name: MOECHS-HK01
-  asn: 4242421522
-  ipv6: fe80::1522
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: hk01.zapto.org
-    remote_port: 23009
-    public_key: McL3+qMK+YrKJHQB5GvDUcUKecsLPaDMFNzlVjjSdDo=


### PR DESCRIPTION
Closes #161

We now have IPv4 only nodes which means we cannot accept any wireguard endpoint from a peer that is an IPv6 address or resolves to an IPv6 address.

This change adds additional validation to ensure that only an IPv4 address or a valid A record will be allowed on a router that is IPv4 only 

Random

* Re-sorted the peers alphabetically