### PR TITLE
Update router.mil1.yml

### DIFF
--- a/routers/router.mil1.yml
+++ b/routers/router.mil1.yml
@@ -1,8 +1,8 @@
 ---
 - name: NETZR-TLV
   asn: 215751
-  ipv4: 172.20.237.193
-  ipv6: fe80::5751
+  ipv4: 192.168.222.222
+  ipv6: fe80::15eb:861b:1ad8:229
   sessions:
     - ipv6
   multiprotocol: true

--- a/routers/router.mil1.yml
+++ b/routers/router.mil1.yml
@@ -1,7 +1,7 @@
 ---
 - name: NETZR-TLV
   asn: 215751
-  ipv4: 172.20.237.192
+  ipv4: 172.20.237.193
   ipv6: fe80::15eb:861b:1ad8:229
   sessions:
     - ipv6

--- a/routers/router.mil1.yml
+++ b/routers/router.mil1.yml
@@ -1,7 +1,7 @@
 ---
 - name: NETZR-TLV
   asn: 215751
-  ipv4: 192.168.222.222
+  ipv4: 172.20.237.192
   ipv6: fe80::15eb:861b:1ad8:229
   sessions:
     - ipv6


### PR DESCRIPTION
Totally failed to make Mikrotik RouterOS to use link-local address I want it to use.
Would like to have different set of addresses to unify peers logic.