### PR TITLE
fix: MWD2-SYD1 does not appear to be sending extended next-hop

### DIFF
--- a/routers/router.syd1.yml
+++ b/routers/router.syd1.yml
@@ -73,9 +73,10 @@
 
 - name: MWD2-SYD1
   asn: 4242420002
+  ipv4: 172.23.227.1
   ipv6: fe80::2:0
   multiprotocol: true
-  extended_nexthop: true
+  extended_nexthop: false
   sessions:
     - ipv6
   wireguard:


### PR DESCRIPTION
`MWD-SYD1` is not sending extended-next hop information for IPv4 routes:

```
BGP neighbor is fe80::2:0, remote AS 4242420002, local AS 4242420207, external link
  Local Role: undefined
  Remote Role: undefined
 Description: MWD2-SYD1
[...]
    Extended nexthop: advertised  #<-- advertised but not received
[...]
```

FRR is installing an IPv4 route advertised from this neighbor which causes it to become recursive and inactive which is triggering a flapping event on DN42:
```
$ show ip route vrf DN42 172.23.227.0/24
Routing entry for 172.23.227.0/24
  Known via "bgp", distance 20, metric 0, vrf DN42
  Last update 00:00:00 ago
    172.23.227.1 inactive, weight 1

$ show ip route vrf DN42 172.23.227.0/24
Routing entry for 172.23.227.0/24
  Known via "bgp", distance 20, metric 0, vrf DN42, best
  Last update 00:00:01 ago
  * fe80::2558:1, via wg4242422558, weight 1
```

This PR converts the neighbor to a multi-protocol BGP peer, however disables extended nexthop. This will trigger the automation to install a static route for `172.23.227.1/32` via the peering interface. Doing so will stop the route from flapping as the received next-hop will always be valid if the interface is up.