### PR TITLE
chore: Add AS4242420129 PIVIPI to FRA1/AMS1

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -1,16 +1,4 @@
 ---
-- name: COLBY-AMS1
-  asn: 4242422558
-  ipv6: fe80::2558:4
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: nl-ams1.dn42.derix.au
-    remote_port: 20207
-    public_key: aEnSuSUB3ZCrryPAIJxBtH6ZcNgCSeW+dMEceEbiflo=
-
 - name: BARAGOON-AMS
   asn: 4242421732
   ipv4: 172.23.32.152
@@ -22,6 +10,18 @@
     remote_address: chr-am02.as215887.net
     remote_port: 20207
     public_key: 3GBZ95hfa8TObNlFc7OZ+EiQ/sCSiRicuFHVHxjEFwA=
+
+- name: COLBY-AMS1
+  asn: 4242422558
+  ipv6: fe80::2558:4
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: nl-ams1.dn42.derix.au
+    remote_port: 20207
+    public_key: aEnSuSUB3ZCrryPAIJxBtH6ZcNgCSeW+dMEceEbiflo=
 
 - name: HEXXNET-AMS1
   asn: 4242420225
@@ -46,6 +46,16 @@
     remote_address: ams.peer.highdef.network
     remote_port: 20207
     public_key: EdWVXZMdujdL/jX5FZDjkPQPVaLoWt4C8FowNRbuaTU=
+
+- name: PIVIPI-NL1
+  asn: 4242420129
+  ipv6: fe80::129:1
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: nl1.420129.xyz
+    remote_port: 20207
+    public_key: iZfLBtF6BiQvdKXx4Yl02u+OL6ls35gSpWCRmB9q4lU=
 
 - name: SIRAYUKI-AMS1
   asn: 4242421216

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -84,6 +84,16 @@
     remote_port: 43178
     public_key: x8FhufXIjV9KrHcMYzOhhytLF3TFFSAMH7OClTxZxn0=
 
+- name: PIVIPI-DE1
+  asn: 4242420129
+  ipv6: fe80::129:2
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: de1.420129.xyz
+    remote_port: 20207
+    public_key: N9rGceoiFcc/obnHrqMAmVlrb/E2Br55+doekTKwNF8=
+
 - name: SERNET-DE-FRA1
   asn: 4242423947
   ipv6: fe80::3947:6
@@ -121,6 +131,18 @@
     remote_port: 20207
     public_key: TWQhJYK+ynNz7A4GMAQSHAyUUKTnAYrBfWTzzjzhAFs=
 
+- name: TATK-FRA
+  asn: 4242423152
+  ipv6: fe80::3152:3
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: rt0.de.tatk.network
+    remote_port: 20207
+    public_key: So3HOmzdnLlXcrIrk7lpP+KmoCHPlXNvbXLg73gI5CQ=
+
 - name: TECH9_DE-FRA02
   asn: 4242421588
   ipv4: 172.20.16.141
@@ -145,15 +167,3 @@
     remote_address: vpn.xenot.fr
     remote_port: 58104
     public_key: MDOUBkJTxNHMZq2Bt0pYa6VOzVz+rzN1HKkUo9UADgk=
-
-- name: TATK-FRA
-  asn: 4242423152
-  ipv6: fe80::3152:3
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: rt0.de.tatk.network
-    remote_port: 20207
-    public_key: So3HOmzdnLlXcrIrk7lpP+KmoCHPlXNvbXLg73gI5CQ=


### PR DESCRIPTION
Submissions from Google Form

#131 #165 were the relevant PRs to remove the peerings due to no longer resolving DNS