### PR TITLE
chore: unpeer with decomm'd SUNNET nodes

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -72,19 +72,6 @@
     remote_port: 21845
     public_key: MZHb2cL0jNZyH1uM01ic3ut3cUZEXC+hiJMthR7s0Ww=
 
-- name: SUNNET-NYC1
-  asn: 4242423088
-  ipv6: fe80::3088:194
-  local_ipv6: fe80::abcd/64
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: 192.3.165.229
-    remote_port: 20207
-    public_key: wAI2D+0GeBnFUqm3xZsfvVlfGQ5iDWI/BykEBbkc62c=
-
 - name: TATK-NYC1
   asn: 4242423152
   ipv6: fe80::3152:4

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -118,19 +118,6 @@
     remote_port: 20207
     public_key: Lqmjk6hqNdReob93K6iYnzwvbWadJKaT/cL96ij2Fm4=
 
-- name: SUNNET-FRA1
-  asn: 4242423088
-  ipv6: fe80::3088:195
-  local_ipv6: fe80::abcd/64
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: 2a0f:9441:47:88::2
-    remote_port: 20207
-    public_key: TWQhJYK+ynNz7A4GMAQSHAyUUKTnAYrBfWTzzjzhAFs=
-
 - name: TATK-FRA
   asn: 4242423152
   ipv6: fe80::3152:3

--- a/routers/router.lon1.yml
+++ b/routers/router.lon1.yml
@@ -95,19 +95,6 @@
     remote_port: 20207
     public_key: bj7f6S9zexxpzNzLxLQ+Z74RHVKUUzaa4Ju7kQOw8zU=
 
-- name: SUNNET-LON1
-  asn: 4242423088
-  ipv6: fe80::3088:197
-  local_ipv6: fe80::abcd/64
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: 2a04:92c7:e:6e4::2
-    remote_port: 20207
-    public_key: hYIX+Ea/2h0rL7OY0yahjN+DJZlOaokymoDG8UW1kyg=
-
 - name: TATK-LON
   asn: 4242423152
   ipv6: fe80::3152:1


### PR DESCRIPTION
Mailing list email

AS424243088 will shutdown the following nodes

Node name: nyc1 Location:New York City Expiration Date:11/20/2024
Node name: lon1 Location:London Expiration Date:11/26/2024
Node name: fra1 Location:Frankfurt Expiration Date:11/30/2024
Node name: ams1 Location:Amsterdam Expiration Date:21/20/2024

DN42: AS4242423088 Clearnet: AS7721