### PR TITLE
chore: remove unnecessary local IP

### DIFF
--- a/routers/router.dal1.yml
+++ b/routers/router.dal1.yml
@@ -3,7 +3,6 @@
   asn: 4242421022
   ipv4: 172.22.240.90
   ipv6: fd2e:5e5e:83ad::1022:207
-  local_ipv6: fdb1:e72a:343d::5
   multiprotocol: true
   sessions:
     - ipv6


### PR DESCRIPTION
The `local_ipv6` isn't needed in this case unless we need to do something specific to the tunnel.

If wanting to just use the router's assigned ULA a static route to the /128 can be set up on the peer's end to point across the tunnel. The `local_ipv6` feature is used when we have an actual subnet configured for the tunnel connection.

