### PR TITLE
chore(sin1): update LIBECHO-HK1 remote-address

### DIFF
--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -39,7 +39,7 @@
   sessions:
     - ipv6
   wireguard:
-    remote_address: hk1.vm.libecho.top
+    remote_address: 2401:2660:1000:210:847d:9add:b11c:c5bb
     remote_port: 20207
     public_key: hQgRGnAP4xBHym+R/jf7ScjGbBDz5RXi5gF6CF7RiWg=
 


### PR DESCRIPTION
Unfortunately this peer's DNS record: `hk1.vm.libecho.top` has stopped resolving for multiple days now.

The wireguard tunnel and BGP peering appears to be up so I have set the `remote-address` to the current wireguard peer's remote address.