### PR TITLE
fix(validation): add check for multiprotocol BGP sessions

### DIFF
--- a/routers/router.gru1.yml
+++ b/routers/router.gru1.yml
@@ -27,7 +27,6 @@
   ipv6: fe80::2608
   multiprotocol: true
   sessions:
-    - ipv4
     - ipv6
   wireguard:
     remote_address: 64.181.170.30

--- a/test_validate_config.py
+++ b/test_validate_config.py
@@ -159,6 +159,12 @@ class TestValidateConfig(unittest.TestCase):
         for session in sessions_valid:
             self.assertEqual(validate_sessions(**session), [])
 
+        session_ipv4_multiprotocol = {
+            'sessions': ['ipv4'],
+            'peer': {'multiprotocol': True, 'ipv4': '192.168.1.1'}
+        }
+        self.assertEqual(validate_sessions(**session_ipv4_multiprotocol), ["sessions: 'ipv4' cannot be used with multiprotocol"])
+
     def test_validate_wireguard(self):
         not_dict = []
         self.assertEqual(validate_wireguard(not_dict), f"wireguard: '{not_dict}' must be type dictionary")

--- a/validate_config.py
+++ b/validate_config.py
@@ -203,6 +203,10 @@ def validate_sessions(sessions, peer):
     if "ipv6" in sessions and "ipv6" not in peer:
         errors.append("ipv6 required when sessions['ipv6']")
 
+    if "ipv4" in sessions and "multiprotocol" in peer:
+        if peer["multiprotocol"]:
+            errors.append("sessions: 'ipv4' cannot be used with multiprotocol")
+
     return errors
 
 


### PR DESCRIPTION
Add check to ensure `ipv4` BGP sessions are not used with `multiprotocol: true`