### PR TITLE
chore: remove peers with invalid DN42 registry information

### DIFF
--- a/routers/router.iad1.yml
+++ b/routers/router.iad1.yml
@@ -11,16 +11,6 @@
     remote_port: 40207
     public_key: EA5yNAPbCXbV2vlxx1tC/X1KEmkHgTDEt5HMv+4SvSQ=
 
-- name: SADDLE-US-QAS-1
-  asn: 211535
-  ipv4: 172.23.66.194
-  sessions:
-    - ipv4
-  wireguard:
-    remote_address: us-qas-1.saddle.network
-    remote_port: 51820
-    public_key: itmJ4Z8V1aNN368P6kMzuQM+GdzWbBKZjJiXrgSeGlw=
-
 - name: TECH9_US-QAS01
   asn: 4242421588
   ipv4: 172.20.16.143

--- a/routers/router.mil1.yml
+++ b/routers/router.mil1.yml
@@ -9,18 +9,6 @@
   wireguard:
     public_key: 1pT6AuQJkQdoASgXi84gWSlu6cCZI/tMH+kUYSd3v0I=
 
-- name: NETZR-TLV
-  asn: 215751
-  ipv4: 172.20.237.193
-  ipv6: fe80::15eb:861b:1ad8:229
-  sessions:
-    - ipv6
-  multiprotocol: true
-  wireguard:
-    remote_address: tlv.dn42.kolo.dev
-    remote_port: 10207
-    public_key: FeuGGxrYAimEdDPyPz96t74PxoTv/QNCW1UT0Bi37nA=
-
 - name: NICHOLASSYSTEMS
   asn: 4242423885
   ipv4: 172.22.98.32


### PR DESCRIPTION
The following ASNs are no longer present in the DN42 registry:
- AS215751 (PR #106)
- AS211535 (PR #213)

These peers are being removed from the configuration.