### PR TITLE
chore: add tunnel IP address validation

### DIFF
--- a/test_validate_config.py
+++ b/test_validate_config.py
@@ -111,9 +111,20 @@ class TestValidateConfig(unittest.TestCase):
         }
         self.assertEqual(validate_ip(**ipv6_address_not_in_range), f"{ipv6_address_not_in_range['attrib']}: '{ipv6_address_not_in_range['addr']}' is not within fe80::/10 or fc00::/7")
 
+         # ensure the IP address is not the subnet or broadcast address
+        ipv4_subnet_address = {'addr': '172.20.0.0/24', 'af': 'ipv4', 'attrib': 'test'}
+        self.assertEqual(validate_ip(**ipv4_subnet_address), f"{ipv4_subnet_address['attrib']}: '{ipv4_subnet_address['addr']}' cannot be the subnet address")
+
+        ipv4_broadcast_address = {'addr': '172.20.0.255/24', 'af': 'ipv4', 'attrib': 'test'}
+        self.assertEqual(validate_ip(**ipv4_broadcast_address), f"{ipv4_broadcast_address['attrib']}: '{ipv4_broadcast_address['addr']}' cannot be the broadcast address")
+
+        ipv6_subnet_address = {'addr': 'fd00:42::/48', 'af': 'ipv6', 'attrib': 'test'}
+        self.assertEqual(validate_ip(**ipv6_subnet_address), f"{ipv6_subnet_address['attrib']}: '{ipv6_subnet_address['addr']}' cannot be the subnet address")
+
+
         valid_addresses_or_prefixes = [
             { 'addr': '172.20.1.1', 'af': 'ipv4', 'attrib': 'test'}, # IPv4 address
-            { 'addr': '172.20.0.0/24', 'af': 'ipv4', 'attrib': 'test'}, # IPv4 prefix
+            { 'addr': '172.20.0.1/24', 'af': 'ipv4', 'attrib': 'test'}, # IPv4 prefix
             { 'addr': 'fe80::100', 'af': 'ipv6', 'attrib': 'test'}, # Link Local address
             { 'addr': 'fe80::100/64', 'af': 'ipv6', 'attrib': 'test'}, # Link Local prefix
             { 'addr': 'fd00::100', 'af': 'ipv6', 'attrib': 'test'}, # ULA Address

--- a/validate_config.py
+++ b/validate_config.py
@@ -182,6 +182,8 @@ def validate_ip(addr, af, attrib):
             return f"{attrib}: '{addr}' is not an IPv4 address"
         if not ip.subnet_of(ipaddress.ip_network("172.20.0.0/14")):
             return f"{attrib}: '{addr}' is not within 172.20.0.0/14"
+        if ip.num_addresses > 2 and  ip.broadcast_address == ipaddress.ip_interface(addr).ip:
+            return f"{attrib}: '{addr}' cannot be the broadcast address"
 
     if af == "ipv6":
         if ip.version != 6:
@@ -189,6 +191,8 @@ def validate_ip(addr, af, attrib):
         if not ip.is_link_local and not ip.subnet_of(ipaddress.ip_network("fc00::/7")):
             return f"{attrib}: '{addr}' is not within fe80::/10 or fc00::/7"
 
+    if ip.num_addresses > 2 and ip.network_address == ipaddress.ip_interface(addr).ip:
+        return f"{attrib}: '{addr}' cannot be the subnet address"
 
 def validate_sessions(sessions, peer):
     errors = []


### PR DESCRIPTION
Add validations to ensure that:
- The peer's IPv4 tunnel address (`ipv4:`) is:
  - not the subnet address
  - not the broadcast address
- The peer's IPv6 tunnel address (`ipv6:`) is:
  - not the subnet address

These validations are gated on subnet sizes greater that 2 addresses. This should exempt `/32` or `/128` specific instances as well as allow for `/31` addressing.

We should probably consider updating these keys to be more descriptive as they have generated some confusion in the past.