### PR TITLE
change cowgl endpoint

### DIFF
--- a/routers/router.osa1.yml
+++ b/routers/router.osa1.yml
@@ -7,6 +7,6 @@
     - ipv4
     - ipv6
   wireguard:
-    remote_address: cowgl.xyz
+    remote_address: cowgl.us.kg
     remote_port: 30207
     public_key: mGGBczSVKW+7UKRquI2GkbKrfxiATv9r4uF5WTP+vWI=


### PR DESCRIPTION
My domain `cowgl.xyz` has expired and will likely stop working soon, so I've changed my endpoint to another domain I own.