### PR TITLE
chore(lax1): remove MOECHS-US01

### DIFF
--- a/routers/router.lax1.yml
+++ b/routers/router.lax1.yml
@@ -53,18 +53,6 @@
   wireguard:
     public_key: UyNSBSItFrMl46v5WI1Uj5VwZCzzCpGQz31AeLxbZxQ=
 
-- name: MOECHS-US01
-  asn: 4242421522
-  ipv6: fe80::1522
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: us01.myftp.org
-    remote_port: 23009
-    public_key: JtesX7JLjlYmZWbeMvK2Hx0Vpo5Fhr9VILlTcuonlWQ=
-
 - name: SERNET-US-LAX1
   asn: 4242423947
   ipv6: fe80::3947:4


### PR DESCRIPTION
Remove `MOECHS-US01`. DNS has failed to respond for their endpoint for multiple days and their peering is down:

```
IPv4 Unicast Summary:

Neighbor           V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
fe80::1522         4 4242421522         0      7047        0    0    0    never       Active        0 MOECHS-US01

IPv6 Unicast Summary:

Neighbor                V         AS   MsgRcvd   MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd   PfxSnt Desc
fe80::1522              4 4242421522         0      7047        0    0    0    never       Active        0 MOECHS-US01
```

They are welcome to submit another PR to re-request peering in the future.

Related #153