### PR TITLE
chore: remove SERNET for DNS non-resolution

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -60,18 +60,6 @@
     remote_port: 42691
     public_key: SODW7Q2gThSlNEnJrKJHSe8zd4nW8SHjxJuQ2YXyWE0=
 
-- name: SERNET-US-NYC1
-  asn: 4242423947
-  ipv6: fe80::3947:7
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: us-nyc1.dn42.sherpherd.top
-    remote_port: 20207
-    public_key: PXkGrHooCFnB6N8bD6isgVjhl9GvzD2CLqlA+e2XikM=
-
 - name: STARSTORM-NYC1
   asn: 4242420275
   ipv4: 172.20.159.98

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -116,18 +116,6 @@
     remote_port: 20207
     public_key: N9rGceoiFcc/obnHrqMAmVlrb/E2Br55+doekTKwNF8=
 
-- name: SERNET-DE-FRA1
-  asn: 4242423947
-  ipv6: fe80::3947:6
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: de-fra1.dn42.sherpherd.top
-    remote_port: 20207
-    public_key: KCd+kXNhe48hwOWng77V9E94PszQBqQvJW42c1P+6nk=
-
 - name: SFS-FRA
   asn: 4242421780
   ipv6: fe80::102

--- a/routers/router.lax1.yml
+++ b/routers/router.lax1.yml
@@ -52,15 +52,3 @@
     - ipv6
   wireguard:
     public_key: UyNSBSItFrMl46v5WI1Uj5VwZCzzCpGQz31AeLxbZxQ=
-
-- name: SERNET-US-LAX1
-  asn: 4242423947
-  ipv6: fe80::3947:4
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: us-lax1.dn42.sherpherd.top
-    remote_port: 20207
-    public_key: 2bQVZJjhIEaEelqwaQ+tbWDERbXjtXyidvYQL5COxyo=


### PR DESCRIPTION
Peer has 3 non-resolvable remote_address, removing

Peer can re-request when they fix it