### PR TITLE
ci: add invalid peer pruning workflow

### DIFF
--- a/.github/workflows/prune_peers.yml
+++ b/.github/workflows/prune_peers.yml
@@ -1,0 +1,52 @@
+# Prune peers with configurations that have become invalid
+name: Prune Invalid Peers
+
+on:
+  # schedule:
+  #   - cron: '0 5 * * *'  # 5am UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prune:
+    name: Prune invalid peers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Prune invalid peers from repository
+        id: prune
+        run: python3 prune.py
+
+      - name: Get report
+        id: report
+        env:
+          PRUNE_STEP: ${{ steps.prune.outputs.stdout }}
+        run: echo $PRUNE_STEP | awk '/^=/{found=1; next} found'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore: prune invalid peers"
+          branch: actions/prune-peers
+          delete-branch: true
+          title: 'chore: prune invalid peers'
+          body: |
+            ## Prune peers with invalid configuration
+            ${{ steps.report.outputs.stdout }}

--- a/prune.py
+++ b/prune.py
@@ -1,0 +1,65 @@
+# Prune invalid peers from routers
+import os
+
+from routedbits import RoutedBits
+
+from interactive import load_router_peers, save_router_peers
+from validate_config import validate
+
+
+def add_report_entry(report, router, peer, errors):
+    """Add a removed peer to the report"""
+    messages = report.get(router, [])
+    messages.append({"name": peer["name"], "reasons": errors})
+
+    report[router] = messages
+    return report[router]
+
+
+def print_report(report):
+    """Print the contents of the report summary"""
+    print("============ PRUNE REPORT ============")
+
+    if len(report):
+        for router, peers in report.items():
+            print(f"### {router}")
+            for peer in peers:
+                print(f"- {peer['name']}")
+                for reason in peer["reasons"]:
+                    print(f"  * {reason}")
+            print("")
+    else:
+        print("No changes.")
+
+
+def main():
+    node_types = {
+        node["hostname"]: node["type"]
+        for node in RoutedBits().nodes(minimal=True)  # noqa
+    }
+    report = {}
+
+    for yaml_file in sorted(os.listdir("routers")):
+        router = yaml_file[:-4]
+        peers = load_router_peers(router)
+
+        print(f"------------ {router} ------------")
+
+        if peers:
+            node_type = node_types[router]
+
+            for peer in peers:
+                errors = list(validate(node_type, peer))
+                is_invalid = bool(len(errors))
+
+                if is_invalid:
+                    add_report_entry(report, router, peer, errors)
+                    peers.remove(peer)
+
+            save_router_peers(router, peers)
+
+    print_report(report)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A simple workflow to prune peers from the repository when they have become invalid.

This first commit sets the PR to only action on manual dispatches. This could become a scheduled job in the future.