### PR TITLE
ci: fix prune output

### DIFF
--- a/.github/workflows/prune_peers.yml
+++ b/.github/workflows/prune_peers.yml
@@ -33,9 +33,10 @@ jobs:
       - name: Prune invalid peers from repository
         id: prune
         run: |
-          output=$(python3 -u prune.py | tee /dev/tty)
-          markdown="$(echo $output | awk '/^=/{found=1; next} found')"
+          output=$(python3 -u prune.py)
+          echo $output
 
+          markdown="$(echo $output | awk '/^=/{found=1; next} found')"
           echo "markdown_report>>EOF" >> $GITHUB_OUTPUT
           echo "$markdown" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix the prune workflow to hopefully produce the desired report.

I was attempting to `tee` the output of the prune script while also saving its output. Now the script will complete, dump its entire output to the log and then attempt to pull the report at the end for the PR.