### PR TITLE
ci: fix prune PR message [skip ci]

### DIFF
--- a/.github/workflows/prune_peers.yml
+++ b/.github/workflows/prune_peers.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           markdown="$(cat prune-report.txt | awk '/^=/{found=1; next} found')"
           echo "## Prune peers with invalid configuration" > prune-report.md
-          echo $markdown >> prune-report.md
+          echo "$markdown" >> prune-report.md
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/prune_peers.yml
+++ b/.github/workflows/prune_peers.yml
@@ -40,6 +40,7 @@ jobs:
           markdown="$(cat prune-report.txt | awk '/^=/{found=1; next} found')"
           echo "## Prune peers with invalid configuration" > prune-report.md
           echo "$markdown" >> prune-report.md
+          echo -e "\n\n*Mark this PR ready for review to trigger checks*" >> prune-report.md
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
@@ -49,3 +50,5 @@ jobs:
           delete-branch: true
           title: 'chore: prune invalid peers'
           body-path: prune-report.md
+          labels: maintenance
+          draft: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,6 +3,11 @@ name: Pull Request
 on:
   pull_request:
     branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   lint:


### PR DESCRIPTION
* Resolved issue with PR message body
* Updated workflow to mark PR as draft
   - PRs created by using the `GITHUB_TOKEN` will not trigger checks to run. [See docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)
   - By creating them as draft PR's we should be able to mark them ready for review to trigger the check to then run