### PR TITLE
Remove my problematic ap01 node

### DIFF
--- a/routers/router.sin1.yml
+++ b/routers/router.sin1.yml
@@ -43,18 +43,6 @@
     remote_port: 20207
     public_key: vBcYFxMLwcsVScQ0LqkGDEIbbykskatmqWHlPGEUrE8=
 
-- name: MDR-AP01
-  asn: 4242420401
-  ipv6: fe80::401:2
-  multiprotocol: true
-  extended_nexthop: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: ap01.dn42.markround.com
-    remote_port: 50207
-    public_key: hxKPfgcJqROFCs8AF8unVj3ie0UYYTmJIfEu01YVVmM=
-
 - name: SERNET-HK1
   asn: 4242423947
   ipv6: fe80::3947:1


### PR DESCRIPTION
This node has been nothing but trouble since I deployed it, so just deleting it and will submit a new peering request later once I've switched everything to a new provider and can confirm it's more reliable/stable.