### PR TITLE
router.ams1: remove 4242421495 peering

### DIFF
--- a/routers/router.ams1.yml
+++ b/routers/router.ams1.yml
@@ -47,16 +47,6 @@
     remote_port: 20207
     public_key: EdWVXZMdujdL/jX5FZDjkPQPVaLoWt4C8FowNRbuaTU=
 
-- name: LE-FAY-NL
-  asn: 4242421495
-  ipv6: fe80::1
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: vtnet0.nl-myb-1.le-fay.org
-    remote_port: 12004
-    public_key: Hy81+bxn3nq0d/eZmNFsGqs+4XO+y9hW9Y+3vUPd3XU=
-
 - name: PIVIPI-NL1
   asn: 4242420129
   ipv6: fe80::129:1


### PR DESCRIPTION
nl-myb-1 doesn't have IPv4 clearnet, so remove peering with IPv4-only router.ams1.