### PR TITLE
feat: add ability to validate single router

### DIFF
--- a/test_validate_config.py
+++ b/test_validate_config.py
@@ -21,16 +21,16 @@ class TestValidateConfig(unittest.TestCase):
 
     def test_validate_unique_peers(self):
         not_unique = [
-            '192.0.2.1/24',
-            '192.0.2.1/24'
+            {'name': 'peer_a', 'ipv4': '192.0.2.1'},
+            {'name': 'peer_b', 'ipv4': '192.0.2.1'}
         ]
-        self.assertFalse(validate_unique_peers(not_unique))
+        self.assertEqual(list(validate_unique_peers(not_unique[0], not_unique)), [f"ipv4 address ({not_unique[0]['ipv4']}) must be unique per router: conflict with peer_b"])
 
         unique = [
-            '192.0.2.1/24',
-            '192.0.2.2/24'
+            {'name': 'peer_a', 'ipv4': '192.0.2.1'},
+            {'name': 'peer_b', 'ipv4': '192.0.2.2'}
         ]
-        self.assertTrue(validate_unique_peers(unique))
+        self.assertEqual(list(validate_unique_peers(unique[0], unique)), [])
         
     def test_validate_asn(self):        
         private_asn = 65000

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import dns.resolver
 import github_action_utils as github
 import ipaddress
@@ -22,7 +23,7 @@ class SafeLineLoader(SafeLoader):
 
 valid_asns = []
 
-def main():
+def main(args):
     errors = []
     file_count = 0
 
@@ -30,7 +31,11 @@ def main():
 
     node_types = { node["hostname"]: node["type"] for node in RoutedBits().nodes(minimal=True) }
 
-    for yaml_file in sorted(os.listdir("routers")):
+    nodes = sorted(os.listdir("routers"))
+    if args.router:
+        nodes = [f"{args.router}.yml"]
+
+    for yaml_file in nodes:
         filename = f"routers/{yaml_file}"
         router = yaml_file[:-4]
         peers = read_yaml(filename)
@@ -282,4 +287,7 @@ def validate_wireguard(wg, require_ipv4=False):
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='Validate dn42-peers')
+    parser.add_argument('--router', help='Run validation against specific router')
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
* Add ability to validate a single router
  * If no router is specified it will continue to validate all routers to preserve previous behavior

```
-> python validate_config.py --router router.ewr1               
Validating peer: CDUBS-NJ... ok 
Validating peer: COLBY-NYC1... ok 
Validating peer: EXABYTE-NJ... ok 
Validating peer: KIOUBIT-US2... ok 
Validating peer: LE-FAY-NY... ok 
Validating peer: LUTOMA-NYC... ok 
Validating peer: SDUBS-TOR... ok 
Validating peer: STARSTORM-NYC1... ok 
Validating peer: STEPNEM-NYC1... ok 
Validating peer: TATK-NYC1... ok 

-> python validate_config.py          
Validating peer: BARAGOON-AMS... ok 
Validating peer: COLBY-AMS1... ok 
Validating peer: HEXXNET-AMS1... ok 
Validating peer: HIGHDEF-AMS... ok 
Validating peer: PIVIPI-NL1... ok 
Validating peer: SIRAYUKI-AMS1... ok 
Validating peer: STEPNEM-AMS1... ok 
Validating peer: TATK-AMS... ok 
Validating peer: THIJN-AMS1... ok 
Validating peer: VENTILAAR-AMS01... ok 
```