### PR TITLE
add LARE autopeerings

### DIFF
--- a/routers/router.chi1.yml
+++ b/routers/router.chi1.yml
@@ -57,6 +57,18 @@
     remote_address: 195.252.199.45
     remote_port: 30207
 
+- name: LARE-USE2
+  asn: 4242423035
+  ipv6: fe80::3035:137
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: use2.dn42.lare.cc
+    remote_port: 20207
+    public_key: AREskFoxP2cd6DXoJ7druDsiWKX+8TwrkQqfi4JxRRw=
+
 - name: SDUBS-CHI
   asn: 4242420202
   ipv6: fe80::202:1

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -93,6 +93,18 @@
     remote_port: 20207
     public_key: B1xSG/XTJRLd+GrWDsB06BqnIq8Xud93YVh/LYYYtUY=
 
+- name: LARE-DE01
+  asn: 4242423035
+  ipv6: fe80::3035:130
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: de01.dn42.lare.cc
+    remote_port: 20207
+    public_key: OL2LE2feDsFV+fOC4vo4u/1enuxf3m2kydwGRE2rKVs=
+
 - name: LUTOMA-FRA
   asn: 64719
   interface: wg4264719

--- a/routers/router.lax1.yml
+++ b/routers/router.lax1.yml
@@ -55,6 +55,18 @@
     remote_port: 20207
     public_key: 7HzHyeA2M7yo/zVmc+e0zG+I7j2SnIx+7ZpXOca93mg=
 
+- name: LARE-USW1
+  asn: 4242423035
+  ipv6: fe80::3035:132
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: usw1.dn42.lare.cc
+    remote_port: 20207
+    public_key: Qd2XCotubH4QrQIdTZjYG4tFs57DqN7jawO9vGz+XWM=
+
 - name: MAIYUN-AB06
   asn: 4242420893
   ipv6: fe80::893

--- a/routers/router.lon1.yml
+++ b/routers/router.lon1.yml
@@ -71,6 +71,18 @@
     remote_port: 20207
     public_key: sLbzTRr2gfLFb24NPzDOpy8j09Y6zI+a7NkeVMdVSR8=
 
+- name: LARE-UK01
+  asn: 4242423035
+  ipv6: fe80::3035:138
+  multiprotocol: true
+  extended_nexthop: true
+  sessions:
+    - ipv6
+  wireguard:
+    remote_address: uk01.dn42.lare.cc
+    remote_port: 20207
+    public_key: RJaU1kRfiOREvKihiDMFpNrEGpN8td3z+UvHxabOlR0=
+
 - name: LE-FAY-UK-MYB-2
   asn: 4242421495
   ipv6: fe80::1495:5


### PR DESCRIPTION
Add auto-peerings to LARE-MNT at the following locations:

- chi1 - lare-use2
- fra1 - lare-de01
- lax1 - lare-usw1
- lon1 - lare-uk01

They also have Tokyo in close proximity to our tyo1 router, however their site responded with 500 error when configuring that location.