### PR TITLE
refactor(fra1): migrate to new provider

### DIFF
--- a/routers/router.ewr1.yml
+++ b/routers/router.ewr1.yml
@@ -68,7 +68,7 @@
   sessions:
     - ipv6
   wireguard:
-    remote_address: 23.95.146.112
+    remote_address: us-nyc.dn42.lutoma.org
     remote_port: 42691
     public_key: SODW7Q2gThSlNEnJrKJHSe8zd4nW8SHjxJuQ2YXyWE0=
 

--- a/routers/router.fnc1.yml
+++ b/routers/router.fnc1.yml
@@ -95,19 +95,6 @@
     remote_port: 42496
     public_key: 3Fr6ubidGi0X5WZs2Hd9k+dLtjdEVrguM8r8f2ecU2g=
 
-- name: LUTOMA-LAX
-  asn: 64719
-  interface: wg4264719
-  ipv4: 172.22.119.11
-  ipv6: fe80::acab
-  multiprotocol: true
-  sessions:
-    - ipv6
-  wireguard:
-    remote_address: 198.52.125.186
-    remote_port: 42630
-    public_key: R6k4nj41gdCplmSnHLpEdp5p6iqMey7toCRxHjhPiGE=
-
 - name: TATK-SFO
   asn: 4242423152
   ipv6: fe80::3152:6

--- a/routers/router.fra1.yml
+++ b/routers/router.fra1.yml
@@ -114,7 +114,7 @@
   sessions:
     - ipv6
   wireguard:
-    remote_address: 2603:c020:8001:ed42::42
+    remote_address: de-fra.dn42.lutoma.org
     remote_port: 43178
     public_key: x8FhufXIjV9KrHcMYzOhhytLF3TFFSAMH7OClTxZxn0=
 


### PR DESCRIPTION
FRA1 is moving to a new provider, upgrade any IPv6 endpoints to DNS (to resolve to IPv4)

* Remove Lutoma LAX - peer no longer has this node