### PR TITLE
chore: retire peer configuration repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # RoutedBits: DN42 Peering Configuration
 
+**Try our new self-service automatic peering at
+https://dn42.routedbits.io !**
+
+**This repository has been retired**. Already a peer? No problem.
+Log into the new site and self-manage any existing configurations. Please 
+[contact us](https://dn42.routedbits.io/contact) with any issues.
+
+---
+
 This repository contains the peering configuration for each of our
 DN42 routers.
 


### PR DESCRIPTION
Retire the peering configuration repository.

Self-manage peerings at https://dn42.routedbits.io